### PR TITLE
Заменены устаревшие Flutter API на новые

### DIFF
--- a/lib/api/api_registration_service.dart
+++ b/lib/api/api_registration_service.dart
@@ -611,7 +611,9 @@ class RegistrationService {
 
     final mtInstanceId = _uuid.v4();
     final deviceIdBytes = List<int>.generate(8, (_) => _random.nextInt(256));
-    final deviceId = deviceIdBytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    final deviceId = deviceIdBytes
+        .map((b) => b.toRadixString(16).padLeft(2, '0'))
+        .join();
     final possibleDeviceNames = <String>[
       'Samsung Galaxy S23',
       'Samsung Galaxy S22',

--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -286,13 +286,11 @@ class ApiService {
   }
 
   String generateRandomDeviceId() {
-
     final random = Random();
     final bytes = List<int>.generate(8, (_) => random.nextInt(256));
     return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
   }
 
- 
   static Future<void> clearSessionValues() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('session_mt_instanceid');
@@ -316,7 +314,8 @@ class ApiService {
         'locale': spoofedData['locale'] as String? ?? 'ru',
         'deviceLocale': spoofedData['locale'] as String? ?? 'ru',
         'osVersion': spoofedData['os_version'] as String? ?? 'Android 14',
-        'deviceName': spoofedData['device_name'] as String? ?? 'Samsung Galaxy S23',
+        'deviceName':
+            spoofedData['device_name'] as String? ?? 'Samsung Galaxy S23',
         'appVersion': spoofedData['app_version'] as String? ?? '25.21.3',
         'screen': spoofedData['screen'] as String? ?? 'xxhdpi 480dpi 1080x2340',
         'timezone': spoofedData['timezone'] as String? ?? 'Europe/Moscow',
@@ -337,7 +336,8 @@ class ApiService {
           'deviceName':
               generatedData['device_name'] as String? ?? 'Samsung Galaxy S23',
           'appVersion': generatedData['app_version'] as String? ?? '25.21.3',
-          'screen': generatedData['screen'] as String? ?? 'xxhdpi 480dpi 1080x2340',
+          'screen':
+              generatedData['screen'] as String? ?? 'xxhdpi 480dpi 1080x2340',
           'timezone': generatedData['timezone'] as String? ?? 'Europe/Moscow',
           'pushDeviceType': 'GCM',
           'arch': generatedData['arch'] as String? ?? 'arm64-v8a',

--- a/lib/api/api_service_auth.dart
+++ b/lib/api/api_service_auth.dart
@@ -224,12 +224,11 @@ extension ApiServiceAuth on ApiService {
       authToken = currentAccount.token;
       userId = currentAccount.userId;
 
-
       _resetSession();
 
       bool invalidTokenDetected = false;
       StreamSubscription? tempSubscription;
-      
+
       tempSubscription = messages.listen((message) {
         if (message != null && message['type'] == 'invalid_token') {
           invalidTokenDetected = true;
@@ -262,34 +261,31 @@ extension ApiServiceAuth on ApiService {
           await accountManager.updateAccountProfile(accountId, profileObj);
         }
       } catch (e) {
-      
         tempSubscription?.cancel();
-        
+
         print("Ошибка переключения аккаунта: $e");
-        
-   
+
         if (previousAccountId != null) {
           print("Восстанавливаем предыдущий аккаунт: $previousAccountId");
-          
+
           await accountManager.switchAccount(previousAccountId);
-          
-  
+
           disconnect();
           authToken = previousToken;
           userId = previousUserId;
-          
-         
+
           _resetSession();
-          
-        
+
           try {
             await connect();
             await waitUntilOnline().timeout(const Duration(seconds: 10));
           } catch (reconnectError) {
-            print("Ошибка восстановления предыдущего аккаунта: $reconnectError");
+            print(
+              "Ошибка восстановления предыдущего аккаунта: $reconnectError",
+            );
           }
         }
-        
+
         rethrow;
       } finally {
         tempSubscription?.cancel();

--- a/lib/api/api_service_chats.dart
+++ b/lib/api/api_service_chats.dart
@@ -1291,8 +1291,11 @@ extension ApiServiceChats on ApiService {
 
   Future<Message?> updateChatLastMessage(int chatId) async {
     try {
-      final remainingMessages = await _chatCacheService.getCachedChatMessages(chatId);
-      final newLastMessage = remainingMessages != null && remainingMessages.isNotEmpty
+      final remainingMessages = await _chatCacheService.getCachedChatMessages(
+        chatId,
+      );
+      final newLastMessage =
+          remainingMessages != null && remainingMessages.isNotEmpty
           ? (remainingMessages..sort((a, b) => b.time.compareTo(a.time))).first
           : Message(
               id: 'empty',

--- a/lib/api/api_service_connection.dart
+++ b/lib/api/api_service_connection.dart
@@ -157,10 +157,8 @@ extension ApiServiceConnection on ApiService {
       await prefs.setString('spoof_deviceid', deviceId);
     }
 
-   
     String mtInstanceId = prefs.getString('session_mt_instanceid') ?? '';
     int clientSessionId = prefs.getInt('session_client_session_id') ?? 0;
-    
 
     if (mtInstanceId.isEmpty || clientSessionId == 0) {
       mtInstanceId = const Uuid().v4();
@@ -769,11 +767,9 @@ extension ApiServiceConnection on ApiService {
       return;
     }
 
-
     final persistentItems = _queueService.getPersistentItems();
     print('Обработка постоянной очереди: ${persistentItems.length} элементов');
     for (var item in persistentItems) {
- 
       if (_queueService.isMessageProcessed(item.id)) {
         print(
           'Сообщение ${item.id} уже было обработано, пропускаем и удаляем из очереди',
@@ -792,23 +788,20 @@ extension ApiServiceConnection on ApiService {
               print(
                 'Сообщение из очереди успешно отправлено, удаляем из очереди: ${item.id}',
               );
-             
+
               _queueService.markMessageAsProcessed(item.id);
               _queueService.removeFromQueue(item.id);
             })
             .catchError((e) {
               print('Ошибка отправки из очереди: $e, оставляем в очереди');
-            
             }),
       );
     }
 
- 
     final temporaryItems = _queueService.getTemporaryItems();
     print('Обработка временной очереди: ${temporaryItems.length} элементов');
     for (var item in temporaryItems) {
       if (item.type == QueueItemType.loadChat && item.chatId != null) {
-   
         if (currentActiveChatId == item.chatId) {
           print('Отправляем запрос загрузки чата ${item.chatId} из очереди');
           unawaited(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,29 +33,29 @@ Future<void> _generateInitialAndroidSpoof() async {
   try {
     final prefs = await SharedPreferences.getInstance();
     final isSpoofingEnabled = prefs.getBool('spoofing_enabled') ?? false;
-    
+
     if (isSpoofingEnabled) {
       print('Спуф уже настроен, генерация не требуется');
       return;
     }
-    
+
     print('Генерируем автоматический спуф для Android...');
-    
+
     final androidPresets = devicePresets
         .where((p) => p.deviceType == 'ANDROID')
         .toList();
-    
+
     if (androidPresets.isEmpty) {
       print('Не найдены пресеты для Android');
       return;
     }
-    
+
     final random = Random();
     final preset = androidPresets[random.nextInt(androidPresets.length)];
-    
+
     const uuid = Uuid();
     final deviceId = uuid.v4();
-    
+
     String timezone;
     try {
       final timezoneInfo = await FlutterTimezone.getLocalTimezone();
@@ -63,9 +63,9 @@ Future<void> _generateInitialAndroidSpoof() async {
     } catch (_) {
       timezone = 'Europe/Moscow';
     }
-    
+
     final locale = Platform.localeName.split('_').first;
-    
+
     await prefs.setBool('spoofing_enabled', true);
     await prefs.setBool('anonymity_enabled', true);
     await prefs.setString('spoof_useragent', preset.userAgent);
@@ -77,7 +77,7 @@ Future<void> _generateInitialAndroidSpoof() async {
     await prefs.setString('spoof_deviceid', deviceId);
     await prefs.setString('spoof_devicetype', 'ANDROID');
     await prefs.setString('spoof_appversion', '25.21.3');
-    
+
     print('Спуф для Android успешно сгенерирован:');
     print('  - Устройство: ${preset.deviceName}');
     print('  - ОС: ${preset.osVersion}');
@@ -263,7 +263,7 @@ class MyApp extends StatelessWidget {
           ),
           navigationBarTheme: NavigationBarThemeData(
             backgroundColor: Colors.black,
-            indicatorColor: accentColor.withOpacity(0.4),
+            indicatorColor: accentColor.withValues(alpha: 0.4),
             labelTextStyle: WidgetStateProperty.resolveWith((states) {
               if (states.contains(WidgetState.selected)) {
                 return TextStyle(
@@ -372,10 +372,10 @@ class _MiniFpsHudState extends State<_MiniFpsHud> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
-        color: theme.surface.withOpacity(0.85),
+        color: theme.surface.withValues(alpha: 0.85),
         borderRadius: BorderRadius.circular(10),
         boxShadow: [
-          BoxShadow(color: Colors.black.withOpacity(0.2), blurRadius: 8),
+          BoxShadow(color: Colors.black.withValues(alpha: 0.2), blurRadius: 8),
         ],
       ),
       child: DefaultTextStyle(

--- a/lib/screens/cache_management_screen.dart
+++ b/lib/screens/cache_management_screen.dart
@@ -422,7 +422,7 @@ class _CacheManagementScreenState extends State<CacheManagementScreen> {
                         Container(
                           padding: const EdgeInsets.all(8),
                           decoration: BoxDecoration(
-                            color: colors.primary.withOpacity(0.1),
+                            color: colors.primary.withValues(alpha: 0.1),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Row(

--- a/lib/screens/chat/dialogs/add_chats_to_folder_dialog.dart
+++ b/lib/screens/chat/dialogs/add_chats_to_folder_dialog.dart
@@ -81,7 +81,7 @@ class _AddChatsToFolderDialogState extends State<AddChatsToFolderDialog> {
                 width: 40,
                 height: 4,
                 decoration: BoxDecoration(
-                  color: colors.onSurfaceVariant.withOpacity(0.4),
+                  color: colors.onSurfaceVariant.withValues(alpha: 0.4),
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
@@ -93,7 +93,7 @@ class _AddChatsToFolderDialogState extends State<AddChatsToFolderDialog> {
                 decoration: BoxDecoration(
                   border: Border(
                     bottom: BorderSide(
-                      color: colors.outline.withOpacity(0.2),
+                      color: colors.outline.withValues(alpha: 0.2),
                       width: 1,
                     ),
                   ),
@@ -252,7 +252,7 @@ class _AddChatsToFolderDialogState extends State<AddChatsToFolderDialog> {
                 decoration: BoxDecoration(
                   border: Border(
                     top: BorderSide(
-                      color: colors.outline.withOpacity(0.2),
+                      color: colors.outline.withValues(alpha: 0.2),
                       width: 1,
                     ),
                   ),

--- a/lib/screens/chat/dialogs/read_settings_dialog.dart
+++ b/lib/screens/chat/dialogs/read_settings_dialog.dart
@@ -137,7 +137,7 @@ class _ReadSettingsDialogContentState extends State<ReadSettingsDialogContent> {
             width: 40,
             height: 4,
             decoration: BoxDecoration(
-              color: colors.onSurfaceVariant.withOpacity(0.4),
+              color: colors.onSurfaceVariant.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(2),
             ),
           ),

--- a/lib/screens/chat/dialogs/read_settings_dialog.dart
+++ b/lib/screens/chat/dialogs/read_settings_dialog.dart
@@ -155,53 +155,47 @@ class _ReadSettingsDialogContentState extends State<ReadSettingsDialogContent> {
           const Divider(),
           Flexible(
             child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  RadioListTile<String>(
-                    title: const Text('По умолчанию'),
-                    subtitle: Text(_getDefaultDescription()),
-                    value: 'default',
-                    groupValue: selectedOption,
-                    onChanged: (value) => _setOption(value!),
-                  ),
-                  RadioListTile<String>(
-                    title: const Text('Отключить чтение'),
-                    subtitle: const Text(
-                      'Сообщения не будут отмечаться как прочитанные',
+              child: RadioGroup<String>(
+                groupValue: selectedOption,
+                onChanged: (value) => _setOption(value!),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    RadioListTile<String>(
+                      value: 'default',
+                      title: const Text('По умолчанию'),
+                      subtitle: Text(_getDefaultDescription()),
                     ),
-                    value: 'disabled',
-                    groupValue: selectedOption,
-                    onChanged: (value) => _setOption(value!),
-                  ),
-                  RadioListTile<String>(
-                    title: const Text('Чтение при действиях'),
-                    subtitle: const Text(
-                      'Отмечать прочитанным при отправке сообщения',
+                    RadioListTile<String>(
+                      value: 'disabled',
+                      title: const Text('Отключить чтение'),
+                      subtitle: const Text(
+                        'Сообщения не будут отмечаться как прочитанные',
+                      ),
                     ),
-                    value: 'action',
-                    groupValue: selectedOption,
-                    onChanged: (value) => _setOption(value!),
-                  ),
-                  RadioListTile<String>(
-                    title: const Text('Чтение при входе в чат'),
-                    subtitle: const Text(
-                      'Отмечать прочитанным при открытии чата',
+                    RadioListTile<String>(
+                      value: 'action',
+                      title: const Text('Чтение при действиях'),
+                      subtitle: const Text(
+                        'Отмечать прочитанным при отправке сообщения',
+                      ),
                     ),
-                    value: 'enter',
-                    groupValue: selectedOption,
-                    onChanged: (value) => _setOption(value!),
-                  ),
-                  RadioListTile<String>(
-                    title: const Text('Чтение при действиях и при входе'),
-                    subtitle: const Text(
-                      'Отмечать прочитанным при отправке и при открытии',
+                    RadioListTile<String>(
+                      value: 'enter',
+                      title: const Text('Чтение при входе в чат'),
+                      subtitle: const Text(
+                        'Отмечать прочитанным при открытии чата',
+                      ),
                     ),
-                    value: 'both',
-                    groupValue: selectedOption,
-                    onChanged: (value) => _setOption(value!),
-                  ),
-                ],
+                    RadioListTile<String>(
+                      value: 'both',
+                      title: const Text('Чтение при действиях и при входе'),
+                      subtitle: const Text(
+                        'Отмечать прочитанным при отправке и при открытии',
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/screens/chat/widgets/empty_chat_widget.dart
+++ b/lib/screens/chat/widgets/empty_chat_widget.dart
@@ -34,7 +34,7 @@ class EmptyChatWidget extends StatelessWidget {
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,
-              color: colors.onSurface.withOpacity(0.6),
+              color: colors.onSurface.withValues(alpha: 0.6),
             ),
           ),
         ],

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -121,7 +121,6 @@ class _ChatScreenState extends State<ChatScreen> {
   int? _lastPeerReadMessageId;
   String? _lastPeerReadMessageIdStr;
 
-
   Map<String, dynamic>? _cachedCurrentGroupChat;
 
   final Set<String> _sendingReactions = {};
@@ -184,7 +183,9 @@ class _ChatScreenState extends State<ChatScreen> {
                         child: ElevatedButton.icon(
                           style: ElevatedButton.styleFrom(
                             elevation: 0,
-                            backgroundColor: colors.primary.withOpacity(0.10),
+                            backgroundColor: colors.primary.withValues(
+                              alpha: 0.10,
+                            ),
                             foregroundColor: colors.primary,
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(16),
@@ -744,12 +745,14 @@ class _ChatScreenState extends State<ChatScreen> {
         };
       }
 
-      final draftData = text.trim().isNotEmpty ? {
-        'text': text,
-        'elements': elements,
-        'replyingToMessage': replyingToMessageData,
-        'timestamp': DateTime.now().millisecondsSinceEpoch,
-      } : null;
+      final draftData = text.trim().isNotEmpty
+          ? {
+              'text': text,
+              'elements': elements,
+              'replyingToMessage': replyingToMessageData,
+              'timestamp': DateTime.now().millisecondsSinceEpoch,
+            }
+          : null;
 
       await ChatCacheService().saveChatInputState(
         widget.chatId,
@@ -1126,7 +1129,6 @@ class _ChatScreenState extends State<ChatScreen> {
   void _loadHistoryAndListen() {
     _paginateInitialLoad();
 
-
     ApiService.instance.reconnectionComplete.listen((_) {
       if (mounted && ApiService.instance.currentActiveChatId == widget.chatId) {
         print('Переподключение: перезагружаем чат ${widget.chatId}');
@@ -1142,15 +1144,14 @@ class _ChatScreenState extends State<ChatScreen> {
       final seq = message['seq'];
       final payload = message['payload'];
 
-
       if (payload is! Map<String, dynamic>) return;
 
-      final dynamic incomingChatId = payload['chatId'] ?? payload['chat']?['id'];
+      final dynamic incomingChatId =
+          payload['chatId'] ?? payload['chat']?['id'];
       final int? chatIdNormalized = incomingChatId is int
           ? incomingChatId
           : int.tryParse(incomingChatId?.toString() ?? '');
 
-    
       final shouldCheckChatId =
           opcode != 178 || (opcode == 178 && payload.containsKey('chatId'));
 
@@ -1165,7 +1166,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
         final newMessage = Message.fromJson(messageMap);
 
-   
         final messageId = newMessage.id;
         if (messageId.isNotEmpty && !messageId.startsWith('local_')) {
           final queueService = MessageQueueService();
@@ -1239,7 +1239,9 @@ class _ChatScreenState extends State<ChatScreen> {
         });
       } else if (opcode == 66 || opcode == 142) {
         final rawMessageIds = payload['messageIds'] as List<dynamic>? ?? [];
-        final deletedMessageIds = rawMessageIds.map((id) => id.toString()).toList();
+        final deletedMessageIds = rawMessageIds
+            .map((id) => id.toString())
+            .toList();
         if (deletedMessageIds.isNotEmpty) {
           Future.microtask(() {
             if (mounted) {
@@ -1254,7 +1256,6 @@ class _ChatScreenState extends State<ChatScreen> {
             _pendingReactionSeqs.remove(seq);
             _updateMessageReaction(messageId, payload['reactionInfo'] ?? {});
           } else {
-        
             if (_sendingReactions.isNotEmpty) {
               _sendingReactions.clear();
               _buildChatItems();
@@ -1344,7 +1345,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
   int get _optPage => _ultraOptimize ? 10 : (_optimize ? 50 : _pageSize);
 
-
   Future<void> _paginateInitialLoad() async {
     setState(() => _isLoadingHistory = true);
 
@@ -1425,7 +1425,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
       List<Message> mergedMessages;
       if (hasServerData) {
-    
         final Map<String, Message> messagesMap = {};
 
         final Set<String> serverMessageIds = {};
@@ -1435,11 +1434,13 @@ class _ChatScreenState extends State<ChatScreen> {
           serverMessageIds.add(msg.id);
         }
 
-        final themeProvider = Provider.of<ThemeProvider>(context, listen: false);
+        final themeProvider = Provider.of<ThemeProvider>(
+          context,
+          listen: false,
+        );
         if (themeProvider.showDeletedMessages && hasCache) {
           for (final cachedMsg in _messages) {
-     
-            if (!serverMessageIds.contains(cachedMsg.id) && 
+            if (!serverMessageIds.contains(cachedMsg.id) &&
                 !cachedMsg.id.startsWith('local_')) {
               messagesMap[cachedMsg.id] = cachedMsg.copyWith(isDeleted: true);
             }
@@ -1450,14 +1451,18 @@ class _ChatScreenState extends State<ChatScreen> {
           for (final cachedMsg in _messages) {
             final serverMsg = messagesMap[cachedMsg.id];
             if (serverMsg != null) {
-              if (cachedMsg.originalText != null && serverMsg.originalText == null) {
-                messagesMap[cachedMsg.id] = serverMsg.copyWith(originalText: cachedMsg.originalText);
-              }
-              else if (cachedMsg.text != serverMsg.text &&
-                       cachedMsg.text.isNotEmpty &&
-                       (serverMsg.isEdited || serverMsg.updateTime != null) &&
-                       serverMsg.originalText == null) {
-                messagesMap[cachedMsg.id] = serverMsg.copyWith(originalText: cachedMsg.text);
+              if (cachedMsg.originalText != null &&
+                  serverMsg.originalText == null) {
+                messagesMap[cachedMsg.id] = serverMsg.copyWith(
+                  originalText: cachedMsg.originalText,
+                );
+              } else if (cachedMsg.text != serverMsg.text &&
+                  cachedMsg.text.isNotEmpty &&
+                  (serverMsg.isEdited || serverMsg.updateTime != null) &&
+                  serverMsg.originalText == null) {
+                messagesMap[cachedMsg.id] = serverMsg.copyWith(
+                  originalText: cachedMsg.text,
+                );
               }
             }
           }
@@ -2078,13 +2083,12 @@ class _ChatScreenState extends State<ChatScreen> {
         } else if (oldMessage.originalText != null) {
           return finalMessage.copyWith(originalText: oldMessage.originalText);
         } else if ((finalMessage.isEdited || finalMessage.updateTime != null) &&
-                   finalMessage.text != oldMessage.text) {
+            finalMessage.text != oldMessage.text) {
           return finalMessage.copyWith(originalText: oldMessage.text);
         } else {
           return finalMessage;
         }
       })();
-
 
       final oldHasPhoto = oldMessage.attaches.any((a) => a['_type'] == 'PHOTO');
       final newHasPhoto = finalMessageWithOriginalText.attaches.any(
@@ -2167,16 +2171,15 @@ class _ChatScreenState extends State<ChatScreen> {
         final isMyMessage = message.senderId == _actualMyId;
 
         if (isMyMessage) {
-    
           _removeMessages([messageId]);
-        } else {         
-          if (showDeletedMessages) {    
+        } else {
+          if (showDeletedMessages) {
             _messages[messageIndex] = message.copyWith(isDeleted: true);
             _buildChatItems();
             if (mounted) {
               setState(() {});
             }
-          } else {        
+          } else {
             _removeMessages([messageId]);
           }
         }
@@ -2505,9 +2508,13 @@ class _ChatScreenState extends State<ChatScreen> {
       MessageQueueService().removeFromQueue('msg_$cid');
     }
     _removeMessages([message.id]);
-    unawaited(ApiService.instance.updateChatLastMessage(widget.chatId).then((newLastMessage) {
-      widget.onLastMessageChanged?.call(newLastMessage);
-    }));
+    unawaited(
+      ApiService.instance.updateChatLastMessage(widget.chatId).then((
+        newLastMessage,
+      ) {
+        widget.onLastMessageChanged?.call(newLastMessage);
+      }),
+    );
   }
 
   Future<void> _retryPendingMessage(Message message) async {
@@ -3130,7 +3137,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Map<String, dynamic>? _getCurrentGroupChat() {
-   
     if (_cachedCurrentGroupChat != null) {
       return _cachedCurrentGroupChat;
     }
@@ -3149,7 +3155,6 @@ class _ChatScreenState extends State<ChatScreen> {
       return null;
     }
   }
-
 
   void _invalidateCache() {
     _cachedCurrentGroupChat = null;
@@ -3274,7 +3279,7 @@ class _ChatScreenState extends State<ChatScreen> {
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
-        color: colors.surface.withOpacity(0.92),
+        color: colors.surface.withValues(alpha: 0.92),
         border: Border(bottom: BorderSide(color: colors.outlineVariant)),
       ),
       child: Row(
@@ -3351,17 +3356,17 @@ class _ChatScreenState extends State<ChatScreen> {
                                 onTap: _scrollToPinnedMessage,
                                 child: PinnedMessageWidget(
                                   pinnedMessage: pinnedMessage,
-                              contacts: _contactDetailsCache,
-                              myId: _actualMyId ?? 0,
-                              onTap: _scrollToPinnedMessage,
-                              onClose: () {
-                                _pinnedMessage = null;
-                                _pinnedMessageNotifier.value = null;
-                              },
-                            ),
-                          ),
-                        )
-                      : const SizedBox.shrink(key: ValueKey('empty'));
+                                  contacts: _contactDetailsCache,
+                                  myId: _actualMyId ?? 0,
+                                  onTap: _scrollToPinnedMessage,
+                                  onClose: () {
+                                    _pinnedMessage = null;
+                                    _pinnedMessageNotifier.value = null;
+                                  },
+                                ),
+                              ),
+                            )
+                          : const SizedBox.shrink(key: ValueKey('empty'));
                     },
                   ),
                 ),
@@ -3461,7 +3466,10 @@ class _ChatScreenState extends State<ChatScreen> {
                                       final bool isMe =
                                           item.message.senderId == _actualMyId;
 
-                                      final bool canDeleteForAll = isMe || (widget.isGroupChat && _isCurrentUserAdmin());
+                                      final bool canDeleteForAll =
+                                          isMe ||
+                                          (widget.isGroupChat &&
+                                              _isCurrentUserAdmin());
 
                                       MessageReadStatus? readStatus;
                                       if (isMe) {
@@ -3574,7 +3582,8 @@ class _ChatScreenState extends State<ChatScreen> {
                                           }
                                         }
                                       }
-                                      final stableKey = '${item.message.id}_${item.message.updateTime ?? item.message.time}_${item.message.originalText ?? ''}_${DateTime.now().millisecondsSinceEpoch}';
+                                      final stableKey =
+                                          '${item.message.id}_${item.message.updateTime ?? item.message.time}_${item.message.originalText ?? ''}_${DateTime.now().millisecondsSinceEpoch}';
 
                                       final hasPhoto = item.message.attaches
                                           .any((a) => a['_type'] == 'PHOTO');
@@ -3614,7 +3623,9 @@ class _ChatScreenState extends State<ChatScreen> {
                                       }
 
                                       final bubble = ChatMessageBubble(
-                                        key: message.originalText != null ? ValueKey(stableKey) : UniqueKey(),
+                                        key: message.originalText != null
+                                            ? ValueKey(stableKey)
+                                            : UniqueKey(),
                                         message: item.message,
                                         isMe: isMe,
                                         readStatus: readStatus,
@@ -3640,7 +3651,6 @@ class _ChatScreenState extends State<ChatScreen> {
                                             : null,
                                         onDeleteForMe: isMe
                                             ? () async {
-                                         
                                                 _removeMessages([
                                                   item.message.id,
                                                 ]);
@@ -3651,8 +3661,13 @@ class _ChatScreenState extends State<ChatScreen> {
                                                       item.message.id,
                                                       forMe: true,
                                                     );
-                                                final newLastMessage = await ApiService.instance.updateChatLastMessage(widget.chatId);
-                                                widget.onLastMessageChanged?.call(newLastMessage);
+                                                final newLastMessage =
+                                                    await ApiService.instance
+                                                        .updateChatLastMessage(
+                                                          widget.chatId,
+                                                        );
+                                                widget.onLastMessageChanged
+                                                    ?.call(newLastMessage);
                                               }
                                             : null,
                                         onDeleteForAll: canDeleteForAll
@@ -3666,8 +3681,13 @@ class _ChatScreenState extends State<ChatScreen> {
                                                       item.message.id,
                                                       forMe: false,
                                                     );
-                                                final newLastMessage = await ApiService.instance.updateChatLastMessage(widget.chatId);
-                                                widget.onLastMessageChanged?.call(newLastMessage);
+                                                final newLastMessage =
+                                                    await ApiService.instance
+                                                        .updateChatLastMessage(
+                                                          widget.chatId,
+                                                        );
+                                                widget.onLastMessageChanged
+                                                    ?.call(newLastMessage);
                                               }
                                             : null,
                                         onReaction: (emoji) async {
@@ -3781,7 +3801,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                             color: Theme.of(context)
                                                 .colorScheme
                                                 .primaryContainer
-                                                .withOpacity(0.5),
+                                                .withValues(alpha: 0.5),
                                             borderRadius: BorderRadius.circular(
                                               16,
                                             ),
@@ -3997,7 +4017,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 child: Container(
                   color: Theme.of(
                     context,
-                  ).colorScheme.surface.withOpacity(theme.topBarOpacity),
+                  ).colorScheme.surface.withValues(alpha: theme.topBarOpacity),
                 ),
               ),
             )
@@ -4313,10 +4333,10 @@ class _ChatScreenState extends State<ChatScreen> {
                           ),
                           decoration: BoxDecoration(
                             color: theme.ultraOptimizeChats
-                                ? Colors.red.withOpacity(0.7)
+                                ? Colors.red.withValues(alpha: 0.7)
                                 : theme.optimizeChats
-                                ? Colors.orange.withOpacity(0.7)
-                                : Colors.blue.withOpacity(0.7),
+                                ? Colors.orange.withValues(alpha: 0.7)
+                                : Colors.blue.withValues(alpha: 0.7),
                             borderRadius: BorderRadius.circular(10),
                           ),
                           child: Text(
@@ -4433,7 +4453,7 @@ class _ChatScreenState extends State<ChatScreen> {
                   sigmaX: provider.chatWallpaperBlurSigma,
                   sigmaY: provider.chatWallpaperBlurSigma,
                 ),
-                child: Container(color: Colors.black.withOpacity(0.0)),
+                child: Container(color: Colors.black.withValues(alpha: 0.0)),
               ),
           ],
         );
@@ -4447,7 +4467,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
                 textAlign: TextAlign.center,
               ),
@@ -4492,11 +4512,11 @@ class _ChatScreenState extends State<ChatScreen> {
             decoration: BoxDecoration(
               color: Theme.of(
                 context,
-              ).colorScheme.surface.withOpacity(theme.bottomBarOpacity),
+              ).colorScheme.surface.withValues(alpha: theme.bottomBarOpacity),
               borderRadius: BorderRadius.circular(16),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.1),
+                  color: Colors.black.withValues(alpha: 0.1),
                   blurRadius: 10,
                   offset: const Offset(0, 2),
                 ),
@@ -4516,7 +4536,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       decoration: BoxDecoration(
                         color: Theme.of(
                           context,
-                        ).colorScheme.primaryContainer.withOpacity(0.4),
+                        ).colorScheme.primaryContainer.withValues(alpha: 0.4),
                         borderRadius: BorderRadius.circular(12),
                         border: Border(
                           left: BorderSide(
@@ -4556,9 +4576,10 @@ class _ChatScreenState extends State<ChatScreen> {
                                             : 'Фото'),
                                   style: TextStyle(
                                     fontSize: 13,
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onSurface.withOpacity(0.7),
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurface
+                                        .withValues(alpha: 0.7),
                                   ),
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
@@ -4593,7 +4614,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       decoration: BoxDecoration(
                         color: Theme.of(
                           context,
-                        ).colorScheme.errorContainer.withOpacity(0.4),
+                        ).colorScheme.errorContainer.withValues(alpha: 0.4),
                         borderRadius: BorderRadius.circular(12),
                         border: Border(
                           left: BorderSide(
@@ -4637,9 +4658,10 @@ class _ChatScreenState extends State<ChatScreen> {
                           Text(
                             'или включите block_bypass',
                             style: TextStyle(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onErrorContainer.withOpacity(0.7),
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onErrorContainer
+                                  .withValues(alpha: 0.7),
                               fontSize: 11,
                               fontStyle: FontStyle.italic,
                             ),
@@ -4662,9 +4684,8 @@ class _ChatScreenState extends State<ChatScreen> {
                               child: Icon(
                                 Icons.auto_fix_high,
                                 color: isBlocked
-                                    ? Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface.withOpacity(0.3)
+                                    ? Theme.of(context).colorScheme.onSurface
+                                          .withValues(alpha: 0.3)
                                     : Theme.of(context).colorScheme.primary,
                                 size: 24,
                               ),
@@ -4831,11 +4852,11 @@ class _ChatScreenState extends State<ChatScreen> {
                                           ? Theme.of(context)
                                                 .colorScheme
                                                 .surfaceContainerHighest
-                                                .withOpacity(0.25)
+                                                .withValues(alpha: 0.25)
                                           : Theme.of(context)
                                                 .colorScheme
                                                 .surfaceContainerHighest
-                                                .withOpacity(0.4),
+                                                .withValues(alpha: 0.4),
                                       border: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(24),
                                         borderSide: BorderSide.none,
@@ -4866,7 +4887,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                 ),
                               ],
                             ),
-                      
+
                             StreamBuilder<bool>(
                               stream: Stream.periodic(
                                 const Duration(milliseconds: 500),
@@ -4902,7 +4923,7 @@ class _ChatScreenState extends State<ChatScreen> {
                           ],
                         ),
                       ),
-      
+
                       StreamBuilder<bool>(
                         stream: Stream.periodic(
                           const Duration(milliseconds: 500),
@@ -4945,9 +4966,8 @@ class _ChatScreenState extends State<ChatScreen> {
                             child: Icon(
                               Icons.attach_file,
                               color: isBlocked
-                                  ? Theme.of(
-                                      context,
-                                    ).colorScheme.onSurface.withOpacity(0.3)
+                                  ? Theme.of(context).colorScheme.onSurface
+                                        .withValues(alpha: 0.3)
                                   : Theme.of(context).colorScheme.primary,
                               size: 24,
                             ),
@@ -4966,9 +4986,8 @@ class _ChatScreenState extends State<ChatScreen> {
                               child: Icon(
                                 Icons.animation,
                                 color: isBlocked
-                                    ? Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface.withOpacity(0.3)
+                                    ? Theme.of(context).colorScheme.onSurface
+                                          .withValues(alpha: 0.3)
                                     : Colors.orange,
                                 size: 24,
                               ),
@@ -4981,7 +5000,7 @@ class _ChatScreenState extends State<ChatScreen> {
                           color: isBlocked
                               ? Theme.of(
                                   context,
-                                ).colorScheme.onSurface.withOpacity(0.2)
+                                ).colorScheme.onSurface.withValues(alpha: 0.2)
                               : Theme.of(context).colorScheme.primary,
                           shape: BoxShape.circle,
                         ),
@@ -4995,9 +5014,8 @@ class _ChatScreenState extends State<ChatScreen> {
                               child: Icon(
                                 Icons.send_rounded,
                                 color: isBlocked
-                                    ? Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface.withOpacity(0.5)
+                                    ? Theme.of(context).colorScheme.onSurface
+                                          .withValues(alpha: 0.5)
                                     : Theme.of(context).colorScheme.onPrimary,
                                 size: 24,
                               ),
@@ -5039,9 +5057,10 @@ class _ChatScreenState extends State<ChatScreen> {
                           padding: const EdgeInsets.all(10),
                           margin: const EdgeInsets.only(bottom: 8),
                           decoration: BoxDecoration(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.primaryContainer.withOpacity(0.4),
+                            color: Theme.of(context)
+                                .colorScheme
+                                .primaryContainer
+                                .withValues(alpha: 0.4),
                             borderRadius: BorderRadius.circular(12),
                             border: Border(
                               left: BorderSide(
@@ -5113,7 +5132,7 @@ class _ChatScreenState extends State<ChatScreen> {
                           decoration: BoxDecoration(
                             color: Theme.of(
                               context,
-                            ).colorScheme.errorContainer.withOpacity(0.4),
+                            ).colorScheme.errorContainer.withValues(alpha: 0.4),
                             borderRadius: BorderRadius.circular(12),
                             border: Border(
                               left: BorderSide(
@@ -5162,7 +5181,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                   color: Theme.of(context)
                                       .colorScheme
                                       .onErrorContainer
-                                      .withOpacity(0.7),
+                                      .withValues(alpha: 0.7),
                                   fontSize: 11,
                                   fontStyle: FontStyle.italic,
                                 ),
@@ -5194,11 +5213,11 @@ class _ChatScreenState extends State<ChatScreen> {
                                         ? Theme.of(context)
                                               .colorScheme
                                               .surfaceContainerHighest
-                                              .withOpacity(0.25)
+                                              .withValues(alpha: 0.25)
                                         : Theme.of(context)
                                               .colorScheme
                                               .surfaceContainerHighest
-                                              .withOpacity(0.4),
+                                              .withValues(alpha: 0.4),
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(24),
                                       borderSide: BorderSide.none,
@@ -5224,7 +5243,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                           }
                                         },
                                 ),
-                         
+
                                 StreamBuilder<bool>(
                                   stream: Stream.periodic(
                                     const Duration(milliseconds: 500),
@@ -5262,7 +5281,7 @@ class _ChatScreenState extends State<ChatScreen> {
                               ],
                             ),
                           ),
-                     
+
                           StreamBuilder<bool>(
                             stream: Stream.periodic(
                               const Duration(milliseconds: 500),
@@ -5294,7 +5313,7 @@ class _ChatScreenState extends State<ChatScreen> {
                               );
                             },
                           ),
-                     
+
                           if (!ApiService.instance.isOnline ||
                               !ApiService.instance.isSessionReady)
                             Padding(
@@ -5349,7 +5368,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                           ? Theme.of(context)
                                                 .colorScheme
                                                 .surfaceContainerHighest
-                                                .withOpacity(0.25)
+                                                .withValues(alpha: 0.25)
                                           : Theme.of(
                                               context,
                                             ).colorScheme.primary,
@@ -5361,7 +5380,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                           ? Theme.of(context)
                                                 .colorScheme
                                                 .onSurfaceVariant
-                                                .withOpacity(0.5)
+                                                .withValues(alpha: 0.5)
                                           : Theme.of(
                                               context,
                                             ).colorScheme.onPrimary,
@@ -5391,7 +5410,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                       ? Theme.of(context)
                                             .colorScheme
                                             .surfaceContainerHighest
-                                            .withOpacity(0.25)
+                                            .withValues(alpha: 0.25)
                                       : Theme.of(context).colorScheme.primary,
                                   shape: BoxShape.circle,
                                 ),
@@ -5403,7 +5422,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                       ? Theme.of(context)
                                             .colorScheme
                                             .onSurfaceVariant
-                                            .withOpacity(0.5)
+                                            .withValues(alpha: 0.5)
                                       : Theme.of(context).colorScheme.onPrimary,
                                   size: 20,
                                 ),
@@ -5426,11 +5445,11 @@ class _ChatScreenState extends State<ChatScreen> {
                   decoration: BoxDecoration(
                     color: Theme.of(
                       context,
-                    ).colorScheme.surface.withOpacity(0.85),
+                    ).colorScheme.surface.withValues(alpha: 0.85),
                     borderRadius: BorderRadius.circular(16),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.1),
+                        color: Colors.black.withValues(alpha: 0.1),
                         blurRadius: 10,
                         offset: const Offset(0, 2),
                       ),
@@ -5448,9 +5467,10 @@ class _ChatScreenState extends State<ChatScreen> {
                             padding: const EdgeInsets.all(10),
                             margin: const EdgeInsets.only(bottom: 8),
                             decoration: BoxDecoration(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.primaryContainer.withOpacity(0.4),
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .primaryContainer
+                                  .withValues(alpha: 0.4),
                               borderRadius: BorderRadius.circular(12),
                               border: Border(
                                 left: BorderSide(
@@ -5494,7 +5514,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                           color: Theme.of(context)
                                               .colorScheme
                                               .onSurface
-                                              .withOpacity(0.7),
+                                              .withValues(alpha: 0.7),
                                         ),
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
@@ -5529,9 +5549,10 @@ class _ChatScreenState extends State<ChatScreen> {
                             padding: const EdgeInsets.all(12),
                             margin: const EdgeInsets.only(bottom: 8),
                             decoration: BoxDecoration(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.errorContainer.withOpacity(0.4),
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .errorContainer
+                                  .withValues(alpha: 0.4),
                               borderRadius: BorderRadius.circular(12),
                               border: Border(
                                 left: BorderSide(
@@ -5582,7 +5603,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                     color: Theme.of(context)
                                         .colorScheme
                                         .onErrorContainer
-                                        .withOpacity(0.7),
+                                        .withValues(alpha: 0.7),
                                     fontSize: 11,
                                     fontStyle: FontStyle.italic,
                                   ),
@@ -5612,11 +5633,11 @@ class _ChatScreenState extends State<ChatScreen> {
                                       ? Theme.of(context)
                                             .colorScheme
                                             .surfaceContainerHighest
-                                            .withOpacity(0.25)
+                                            .withValues(alpha: 0.25)
                                       : Theme.of(context)
                                             .colorScheme
                                             .surfaceContainerHighest
-                                            .withOpacity(0.4),
+                                            .withValues(alpha: 0.4),
                                   border: OutlineInputBorder(
                                     borderRadius: BorderRadius.circular(24),
                                     borderSide: BorderSide.none,
@@ -5680,7 +5701,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                             ? Theme.of(context)
                                                   .colorScheme
                                                   .onSurface
-                                                  .withOpacity(0.3)
+                                                  .withValues(alpha: 0.3)
                                             : Theme.of(
                                                 context,
                                               ).colorScheme.primary,
@@ -5708,7 +5729,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                           ? Theme.of(context)
                                                 .colorScheme
                                                 .onSurface
-                                                .withOpacity(0.3)
+                                                .withValues(alpha: 0.3)
                                           : Colors.orange,
                                       size: 24,
                                     ),
@@ -5719,9 +5740,8 @@ class _ChatScreenState extends State<ChatScreen> {
                             Container(
                               decoration: BoxDecoration(
                                 color: isBlocked
-                                    ? Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface.withOpacity(0.2)
+                                    ? Theme.of(context).colorScheme.onSurface
+                                          .withValues(alpha: 0.2)
                                     : Theme.of(context).colorScheme.primary,
                                 shape: BoxShape.circle,
                               ),
@@ -5738,7 +5758,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                           ? Theme.of(context)
                                                 .colorScheme
                                                 .onSurface
-                                                .withOpacity(0.5)
+                                                .withValues(alpha: 0.5)
                                           : Theme.of(
                                               context,
                                             ).colorScheme.onPrimary,
@@ -5868,8 +5888,7 @@ class _ChatScreenState extends State<ChatScreen> {
   void _scrollToResult() {
     if (_currentResultIndex == -1) return;
 
-    if (!mounted || !_itemScrollController.isAttached)
-      return;
+    if (!mounted || !_itemScrollController.isAttached) return;
 
     final targetMessage = _searchResults[_currentResultIndex];
 
@@ -6117,11 +6136,11 @@ class _KometColorPickerBarState extends State<_KometColorPickerBar> {
       margin: const EdgeInsets.only(bottom: 6),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
-        color: colors.surfaceContainerHighest.withOpacity(0.9),
+        color: colors.surfaceContainerHighest.withValues(alpha: 0.9),
         borderRadius: BorderRadius.circular(12),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.12),
+            color: Colors.black.withValues(alpha: 0.12),
             blurRadius: 8,
             offset: const Offset(0, 2),
           ),
@@ -6767,7 +6786,7 @@ class _DateSeparatorChip extends StatelessWidget {
           decoration: BoxDecoration(
             color: Theme.of(
               context,
-            ).colorScheme.primaryContainer.withOpacity(0.5),
+            ).colorScheme.primaryContainer.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(20),
           ),
           child: Text(
@@ -6813,7 +6832,7 @@ class GroupProfileDraggableDialog extends StatelessWidget {
                 width: 40,
                 height: 4,
                 decoration: BoxDecoration(
-                  color: colors.onSurfaceVariant.withOpacity(0.3),
+                  color: colors.onSurfaceVariant.withValues(alpha: 0.3),
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
@@ -6976,7 +6995,9 @@ class _ContactProfileDialogState extends State<ContactProfileDialog> {
                   sigmaY: theme.profileDialogBlur,
                 ),
                 child: Container(
-                  color: Colors.black.withOpacity(theme.profileDialogOpacity),
+                  color: Colors.black.withValues(
+                    alpha: theme.profileDialogOpacity,
+                  ),
                 ),
               ),
             ),
@@ -7032,7 +7053,7 @@ class _ContactProfileDialogState extends State<ContactProfileDialog> {
                       ),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.3),
+                          color: Colors.black.withValues(alpha: 0.3),
                           blurRadius: 16,
                           offset: const Offset(0, -8),
                         ),
@@ -7828,7 +7849,7 @@ class _ControlMessageChip extends StatelessWidget {
           decoration: BoxDecoration(
             color: Theme.of(
               context,
-            ).colorScheme.primaryContainer.withOpacity(0.5),
+            ).colorScheme.primaryContainer.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(20),
           ),
           child: Text(
@@ -8028,7 +8049,7 @@ class _VideoWallpaperBackgroundState extends State<_VideoWallpaperBackground> {
           ),
         ),
 
-        Container(color: Colors.black.withOpacity(0.3)),
+        Container(color: Colors.black.withValues(alpha: 0.3)),
       ],
     );
   }

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -4704,7 +4704,8 @@ class _ChatScreenState extends State<ChatScreen> {
                                     onColorSelected: (color) {
                                       if (_currentKometColorPrefix == null)
                                         return;
-                                      final hex = color.value
+                                      final hex = color
+                                          .toARGB32()
                                           .toRadixString(16)
                                           .padLeft(8, '0')
                                           .substring(2)

--- a/lib/screens/chats_screen.dart
+++ b/lib/screens/chats_screen.dart
@@ -276,7 +276,9 @@ class _ChatsScreenState extends State<ChatsScreen>
   void _updateChatLastMessage(int chatId, Message? newLastMessage) {
     final chatIndex = _allChats.indexWhere((chat) => chat.id == chatId);
     if (chatIndex != -1) {
-      final updatedChat = _allChats[chatIndex].copyWith(lastMessage: newLastMessage);
+      final updatedChat = _allChats[chatIndex].copyWith(
+        lastMessage: newLastMessage,
+      );
       setState(() {
         _allChats[chatIndex] = updatedChat;
       });
@@ -302,7 +304,8 @@ class _ChatsScreenState extends State<ChatsScreen>
       final drafts = <int, Map<String, dynamic>>{};
       for (final chat in _allChats) {
         final draft = await chatCacheService.getChatInputState(chat.id);
-        if (draft != null && draft['text']?.toString().trim().isNotEmpty == true) {
+        if (draft != null &&
+            draft['text']?.toString().trim().isNotEmpty == true) {
           drafts[chat.id] = draft;
         }
       }
@@ -322,11 +325,10 @@ class _ChatsScreenState extends State<ChatsScreen>
   }
 
   void _showTokenExpiredDialog(String message) {
-
     if (_isSwitchingAccounts) {
       return;
     }
-    
+
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -415,9 +417,7 @@ class _ChatsScreenState extends State<ChatsScreen>
             .toList();
         _contacts.clear();
         for (final contactJson in contacts) {
-
-
-        _loadChatDrafts();
+          _loadChatDrafts();
           final contact = Contact.fromJson(
             (contactJson as Map).cast<String, dynamic>(),
           );
@@ -921,7 +921,6 @@ class _ChatsScreenState extends State<ChatsScreen>
         continue;
       }
 
-    
       if (chat.type == 'CHANNEL') {
         final channelTitle = chat.title ?? '';
         final channelDescription = chat.description ?? '';
@@ -934,14 +933,15 @@ class _ChatsScreenState extends State<ChatsScreen>
               chat: chat,
               contact: null,
               matchedText: channelTitle.isNotEmpty ? channelTitle : 'Канал',
-              matchType: channelTitle.toLowerCase().contains(query) ? 'name' : 'description',
+              matchType: channelTitle.toLowerCase().contains(query)
+                  ? 'name'
+                  : 'description',
             ),
           );
         }
         continue;
       }
 
-  
       if (_isGroupChat(chat)) {
         final groupTitle = chat.title ?? '';
         final groupDescription = chat.description ?? '';
@@ -952,9 +952,11 @@ class _ChatsScreenState extends State<ChatsScreen>
           results.add(
             SearchResult(
               chat: chat,
-              contact: null, 
+              contact: null,
               matchedText: groupTitle.isNotEmpty ? groupTitle : 'Группа',
-              matchType: groupTitle.toLowerCase().contains(query) ? 'name' : 'description',
+              matchType: groupTitle.toLowerCase().contains(query)
+                  ? 'name'
+                  : 'description',
             ),
           );
         }
@@ -1317,7 +1319,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                     .toList();
                 _chatsLoaded = true;
                 _listenForUpdates();
-            
+
                 _loadChatDrafts();
                 final contacts = contactListJson.map(
                   (json) => Contact.fromJson(json as Map<String, dynamic>),
@@ -1382,7 +1384,9 @@ class _ChatsScreenState extends State<ChatsScreen>
             bodyContent: bodyContent,
             buildAppBar: _buildAppBar,
             buildAppDrawer: _buildAppDrawer,
-            onAddPressed: widget.isForwardMode ? null : () => _showAddMenu(context),
+            onAddPressed: widget.isForwardMode
+                ? null
+                : () => _showAddMenu(context),
           )
         : bodyContent;
 
@@ -1531,8 +1535,8 @@ class _ChatsScreenState extends State<ChatsScreen>
                               child: Text(
                                 _myProfile?.formattedPhone ?? '',
                                 style: TextStyle(
-                                  color: colors.onPrimaryContainer.withOpacity(
-                                    0.8,
+                                  color: colors.onPrimaryContainer.withValues(
+                                    alpha: 0.8,
                                   ),
                                   fontSize: 14,
                                 ),
@@ -1646,7 +1650,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                                                 if (mounted) {
                                                   setState(() {
                                                     _isAccountsExpanded = false;
-                                             
+
                                                     _allChats.clear();
                                                     _filteredChats.clear();
                                                     _contacts.clear();
@@ -1656,7 +1660,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                                                     _myProfile = null;
                                                     _isProfileLoading = true;
                                                     _chatsLoaded = false;
-                                                    
+
                                                     _loadMyProfile();
                                                     _chatsFuture = (() async {
                                                       try {
@@ -1677,13 +1681,25 @@ class _ChatsScreenState extends State<ChatsScreen>
                                                 }
                                               } catch (e) {
                                                 if (mounted) {
-                                                  final errorMessage = e.toString();
-                                             
-                                                  const invalidTokenKeywords = ['invalid_token', 'FAIL_WRONG_PASSWORD'];
-                                                  final isInvalidToken = invalidTokenKeywords.any(
-                                                    (keyword) => errorMessage.contains(keyword)
-                                                  ) || errorMessage.contains('недействительн');
-                                                  
+                                                  final errorMessage = e
+                                                      .toString();
+
+                                                  const invalidTokenKeywords = [
+                                                    'invalid_token',
+                                                    'FAIL_WRONG_PASSWORD',
+                                                  ];
+                                                  final isInvalidToken =
+                                                      invalidTokenKeywords.any(
+                                                        (keyword) =>
+                                                            errorMessage
+                                                                .contains(
+                                                                  keyword,
+                                                                ),
+                                                      ) ||
+                                                      errorMessage.contains(
+                                                        'недействительн',
+                                                      );
+
                                                   if (isInvalidToken) {
                                                     ScaffoldMessenger.of(
                                                       context,
@@ -1694,7 +1710,10 @@ class _ChatsScreenState extends State<ChatsScreen>
                                                         ),
                                                         backgroundColor:
                                                             colors.error,
-                                                        duration: const Duration(seconds: 4),
+                                                        duration:
+                                                            const Duration(
+                                                              seconds: 4,
+                                                            ),
                                                       ),
                                                     );
                                                   } else {
@@ -1714,7 +1733,8 @@ class _ChatsScreenState extends State<ChatsScreen>
                                               } finally {
                                                 if (mounted) {
                                                   setState(() {
-                                                    _isSwitchingAccounts = false;
+                                                    _isSwitchingAccounts =
+                                                        false;
                                                   });
                                                 }
                                               }
@@ -1975,14 +1995,14 @@ class _ChatsScreenState extends State<ChatsScreen>
                   Icon(
                     Icons.search,
                     size: 64,
-                    color: colors.onSurfaceVariant.withOpacity(0.5),
+                    color: colors.onSurfaceVariant.withValues(alpha: 0.5),
                   ),
                   const SizedBox(height: 16),
                   Text(
                     'Начните вводить для поиска',
                     style: TextStyle(
                       fontSize: 18,
-                      color: colors.onSurfaceVariant.withOpacity(0.7),
+                      color: colors.onSurfaceVariant.withValues(alpha: 0.7),
                     ),
                   ),
                   const SizedBox(height: 8),
@@ -1990,7 +2010,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                     'Или выберите чат из списка выше',
                     style: TextStyle(
                       fontSize: 14,
-                      color: colors.onSurfaceVariant.withOpacity(0.5),
+                      color: colors.onSurfaceVariant.withValues(alpha: 0.5),
                     ),
                   ),
                 ],
@@ -2009,14 +2029,14 @@ class _ChatsScreenState extends State<ChatsScreen>
             Icon(
               Icons.search_off,
               size: 64,
-              color: colors.onSurfaceVariant.withOpacity(0.5),
+              color: colors.onSurfaceVariant.withValues(alpha: 0.5),
             ),
             const SizedBox(height: 16),
             Text(
               'Ничего не найдено',
               style: TextStyle(
                 fontSize: 18,
-                color: colors.onSurfaceVariant.withOpacity(0.7),
+                color: colors.onSurfaceVariant.withValues(alpha: 0.7),
               ),
             ),
             const SizedBox(height: 8),
@@ -2024,7 +2044,7 @@ class _ChatsScreenState extends State<ChatsScreen>
               'Попробуйте изменить поисковый запрос',
               style: TextStyle(
                 fontSize: 14,
-                color: colors.onSurfaceVariant.withOpacity(0.5),
+                color: colors.onSurfaceVariant.withValues(alpha: 0.5),
               ),
             ),
           ],
@@ -2120,7 +2140,9 @@ class _ChatsScreenState extends State<ChatsScreen>
             : null,
         child: contactToUseFinal.photoBaseUrl == null
             ? Text(
-                contactToUseFinal.name.isNotEmpty ? contactToUseFinal.name[0].toUpperCase() : '?',
+                contactToUseFinal.name.isNotEmpty
+                    ? contactToUseFinal.name[0].toUpperCase()
+                    : '?',
                 style: TextStyle(color: colors.onPrimaryContainer),
               )
             : null,
@@ -2303,9 +2325,10 @@ class _ChatsScreenState extends State<ChatsScreen>
                         onLastMessageChanged: (Message? newLastMessage) {
                           _updateChatLastMessage(chat.id, newLastMessage);
                         },
-                        onDraftChanged: (int chatId, Map<String, dynamic>? draft) {
-                          _updateChatDraft(chatId, draft);
-                        },
+                        onDraftChanged:
+                            (int chatId, Map<String, dynamic>? draft) {
+                              _updateChatDraft(chatId, draft);
+                            },
                         onChatRemoved: () {
                           _removeChatLocally(chat.id);
                         },
@@ -2539,7 +2562,10 @@ class _ChatsScreenState extends State<ChatsScreen>
           end: Alignment.bottomRight,
         ),
         border: Border(
-          bottom: BorderSide(color: colors.outline.withOpacity(0.2), width: 1),
+          bottom: BorderSide(
+            color: colors.outline.withValues(alpha: 0.2),
+            width: 1,
+          ),
         ),
       );
     } else if (themeProvider.folderTabsBackgroundType ==
@@ -2552,7 +2578,10 @@ class _ChatsScreenState extends State<ChatsScreen>
           fit: BoxFit.cover,
         ),
         border: Border(
-          bottom: BorderSide(color: colors.outline.withOpacity(0.2), width: 1),
+          bottom: BorderSide(
+            color: colors.outline.withValues(alpha: 0.2),
+            width: 1,
+          ),
         ),
       );
     }
@@ -2565,7 +2594,7 @@ class _ChatsScreenState extends State<ChatsScreen>
             color: colors.surface,
             border: Border(
               bottom: BorderSide(
-                color: colors.outline.withOpacity(0.2),
+                color: colors.outline.withValues(alpha: 0.2),
                 width: 1,
               ),
             ),
@@ -2721,7 +2750,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                     width: 40,
                     height: 4,
                     decoration: BoxDecoration(
-                      color: colors.onSurfaceVariant.withOpacity(0.4),
+                      color: colors.onSurfaceVariant.withValues(alpha: 0.4),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
@@ -2733,7 +2762,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                     decoration: BoxDecoration(
                       border: Border(
                         bottom: BorderSide(
-                          color: colors.outline.withOpacity(0.2),
+                          color: colors.outline.withValues(alpha: 0.2),
                           width: 1,
                         ),
                       ),
@@ -2986,7 +3015,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                 width: 40,
                 height: 4,
                 decoration: BoxDecoration(
-                  color: colors.onSurfaceVariant.withOpacity(0.4),
+                  color: colors.onSurfaceVariant.withValues(alpha: 0.4),
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
@@ -3160,7 +3189,7 @@ class _ChatsScreenState extends State<ChatsScreen>
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 520),
             child: Material(
-              color: colors.surface.withOpacity(0.95),
+              color: colors.surface.withValues(alpha: 0.95),
               elevation: 6,
               borderRadius: BorderRadius.circular(12),
               child: InkWell(
@@ -3396,10 +3425,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                   tooltip: 'Сферум',
                 ),
               IconButton(
-                icon: Icon(
-                  Icons.download,
-                  color: Colors.white,
-                ),
+                icon: Icon(Icons.download, color: Colors.white),
                 onPressed: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(
@@ -3466,7 +3492,7 @@ class _ChatsScreenState extends State<ChatsScreen>
           hintText: 'Поиск в чатах...',
           hintStyle: TextStyle(color: colors.onSurfaceVariant),
           filled: true,
-          fillColor: colors.surfaceContainerHighest.withOpacity(0.3),
+          fillColor: colors.surfaceContainerHighest.withValues(alpha: 0.3),
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(20),
             borderSide: BorderSide.none,
@@ -3863,7 +3889,6 @@ class _ChatsScreenState extends State<ChatsScreen>
       messagePreview = _buildMessagePreviewContent(message, chat, colors);
     }
 
-
     if (isMyMessage) {
       final queueItem = MessageQueueService().findByCid(message.cid ?? 0);
       final bool isPending =
@@ -3988,9 +4013,7 @@ class _ChatsScreenState extends State<ChatsScreen>
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: TextStyle(
-              color: Theme.of(
-                context,
-              ).colorScheme.onSurface, 
+              color: Theme.of(context).colorScheme.onSurface,
               fontWeight: FontWeight.w500,
             ),
           ),
@@ -4072,7 +4095,6 @@ class _ChatsScreenState extends State<ChatsScreen>
         final photoUrl =
             attach['photoUrl'] as String? ?? attach['baseUrl'] as String?;
 
-
         String displayName;
         if (name != null && name.isNotEmpty) {
           displayName = name;
@@ -4113,17 +4135,14 @@ class _ChatsScreenState extends State<ChatsScreen>
       return 'Кнопки';
     }
 
-
     return 'Вложение';
   }
 
   String _getSenderDisplayName(Chat chat, Message message) {
-
     final isGroupChat = _isGroupChat(chat);
     final isChannel = chat.type == 'CHANNEL';
 
     if (!isGroupChat && !isChannel) {
-    
       return '';
     }
 

--- a/lib/screens/chats_screen.dart
+++ b/lib/screens/chats_screen.dart
@@ -1392,7 +1392,7 @@ class _ChatsScreenState extends State<ChatsScreen>
 
     return PopScope(
       canPop: !_isSearchExpanded,
-      onPopInvoked: (didPop) {
+      onPopInvokedWithResult: (didPop, _) {
         if (!didPop && _isSearchExpanded) {
           _clearSearch();
         }

--- a/lib/screens/chats_screen.dart
+++ b/lib/screens/chats_screen.dart
@@ -3926,7 +3926,7 @@ class _ChatsScreenState extends State<ChatsScreen>
               imageUrl: photoUrl,
               fit: BoxFit.cover,
               placeholder: (context, url) => Container(
-                color: Theme.of(context).colorScheme.surfaceVariant,
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 child: Icon(
                   Icons.photo,
                   size: 12,
@@ -3934,7 +3934,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                 ),
               ),
               errorWidget: (context, url, error) => Container(
-                color: Theme.of(context).colorScheme.surfaceVariant,
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 child: Icon(
                   Icons.photo,
                   size: 12,
@@ -3980,7 +3980,9 @@ class _ChatsScreenState extends State<ChatsScreen>
                     imageUrl: photoUrl,
                     fit: BoxFit.cover,
                     placeholder: (context, url) => Container(
-                      color: Theme.of(context).colorScheme.surfaceVariant,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
                       child: Icon(
                         Icons.person,
                         size: 12,
@@ -3988,7 +3990,9 @@ class _ChatsScreenState extends State<ChatsScreen>
                       ),
                     ),
                     errorWidget: (context, url, error) => Container(
-                      color: Theme.of(context).colorScheme.surfaceVariant,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
                       child: Icon(
                         Icons.person,
                         size: 12,
@@ -3997,7 +4001,9 @@ class _ChatsScreenState extends State<ChatsScreen>
                     ),
                   )
                 : Container(
-                    color: Theme.of(context).colorScheme.surfaceVariant,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
                     child: Icon(
                       Icons.person,
                       size: 12,
@@ -4039,7 +4045,7 @@ class _ChatsScreenState extends State<ChatsScreen>
               imageUrl: photoUrl,
               fit: BoxFit.cover,
               placeholder: (context, url) => Container(
-                color: Theme.of(context).colorScheme.surfaceVariant,
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 child: Icon(
                   Icons.photo,
                   size: 12,
@@ -4047,7 +4053,7 @@ class _ChatsScreenState extends State<ChatsScreen>
                 ),
               ),
               errorWidget: (context, url, error) => Container(
-                color: Theme.of(context).colorScheme.surfaceVariant,
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 child: Icon(
                   Icons.photo,
                   size: 12,

--- a/lib/screens/custom_request_screen.dart
+++ b/lib/screens/custom_request_screen.dart
@@ -226,7 +226,9 @@ class _CustomRequestScreenState extends State<CustomRequestScreen> {
             color: Theme.of(context).colorScheme.surfaceContainer,
             borderRadius: BorderRadius.circular(8),
             border: Border.all(
-              color: Theme.of(context).colorScheme.outline.withOpacity(0.5),
+              color: Theme.of(
+                context,
+              ).colorScheme.outline.withValues(alpha: 0.5),
             ),
           ),
           child: _buildResponseContent(),

--- a/lib/screens/debug_screen.dart
+++ b/lib/screens/debug_screen.dart
@@ -375,7 +375,7 @@ class _OutlinedSection extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        border: Border.all(color: colors.outline.withOpacity(0.3)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(12),
       ),
       child: child,

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -263,7 +263,7 @@ class _DownloadsScreenState extends State<DownloadsScreen> {
                           width: 48,
                           height: 48,
                           decoration: BoxDecoration(
-                            color: theme.primaryColor.withOpacity(0.1),
+                            color: theme.primaryColor.withValues(alpha: 0.1),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Icon(

--- a/lib/screens/group_settings_screen.dart
+++ b/lib/screens/group_settings_screen.dart
@@ -756,7 +756,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                       Container(
                         padding: const EdgeInsets.all(12),
                         decoration: BoxDecoration(
-                          color: colorScheme.surfaceVariant.withValues(
+                          color: colorScheme.surfaceContainerHighest.withValues(
                             alpha: 0.5,
                           ),
                           borderRadius: BorderRadius.circular(8),

--- a/lib/screens/group_settings_screen.dart
+++ b/lib/screens/group_settings_screen.dart
@@ -710,8 +710,8 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                   end: Alignment.bottomCenter,
                   colors: [
                     Colors.transparent,
-                    Colors.black.withOpacity(0.1),
-                    Colors.black.withOpacity(0.5),
+                    Colors.black.withValues(alpha: 0.1),
+                    Colors.black.withValues(alpha: 0.5),
                   ],
                   stops: const [0.5, 0.7, 1.0],
                 ),
@@ -756,10 +756,12 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                       Container(
                         padding: const EdgeInsets.all(12),
                         decoration: BoxDecoration(
-                          color: colorScheme.surfaceVariant.withOpacity(0.5),
+                          color: colorScheme.surfaceVariant.withValues(
+                            alpha: 0.5,
+                          ),
                           borderRadius: BorderRadius.circular(8),
                           border: Border.all(
-                            color: colorScheme.outline.withOpacity(0.3),
+                            color: colorScheme.outline.withValues(alpha: 0.3),
                           ),
                         ),
                         child: Column(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1245,7 +1245,7 @@ class _DesktopLayoutState extends State<_DesktopLayout> {
               cursor: SystemMouseCursors.resizeLeftRight,
               child: Container(
                 width: 4.0,
-                color: colors.outline.withOpacity(0.3),
+                color: colors.outline.withValues(alpha: 0.3),
               ),
             ),
           ),
@@ -1264,7 +1264,7 @@ class _DesktopLayoutState extends State<_DesktopLayout> {
                               Icon(
                                 Icons.message,
                                 size: 80,
-                                color: colors.primary.withOpacity(0.5),
+                                color: colors.primary.withValues(alpha: 0.5),
                               ),
                               const SizedBox(height: 16),
                               Text(

--- a/lib/screens/join_group_screen.dart
+++ b/lib/screens/join_group_screen.dart
@@ -404,7 +404,7 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
                 Container(
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: colors.primaryContainer.withOpacity(0.3),
+                    color: colors.primaryContainer.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Column(
@@ -464,7 +464,9 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
                   decoration: BoxDecoration(
                     color: colors.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: colors.outline.withOpacity(0.3)),
+                    border: Border.all(
+                      color: colors.outline.withValues(alpha: 0.3),
+                    ),
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -540,7 +542,7 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
           ),
           if (_isLoading)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(child: CircularProgressIndicator()),
             ),
         ],

--- a/lib/screens/music_library_screen.dart
+++ b/lib/screens/music_library_screen.dart
@@ -140,7 +140,7 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
           builder: (context, isFullscreen, _) {
             return PopScope(
               canPop: !isPlayerExpanded,
-              onPopInvoked: (didPop) {
+              onPopInvokedWithResult: (didPop, _) {
                 if (!didPop && isPlayerExpanded) {
                   BottomSheetMusicPlayer.isExpandedNotifier.value = false;
                   BottomSheetMusicPlayer.isFullscreenNotifier.value = false;

--- a/lib/screens/music_library_screen.dart
+++ b/lib/screens/music_library_screen.dart
@@ -162,14 +162,16 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                 Icon(
                                   Icons.music_off,
                                   size: 64,
-                                  color: colorScheme.onSurface.withOpacity(0.5),
+                                  color: colorScheme.onSurface.withValues(
+                                    alpha: 0.5,
+                                  ),
                                 ),
                                 const SizedBox(height: 16),
                                 Text(
                                   'Нет музыки',
                                   style: theme.textTheme.titleLarge?.copyWith(
-                                    color: colorScheme.onSurface.withOpacity(
-                                      0.7,
+                                    color: colorScheme.onSurface.withValues(
+                                      alpha: 0.7,
                                     ),
                                   ),
                                 ),
@@ -177,8 +179,8 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                 Text(
                                   'Скачайте музыку из чатов',
                                   style: theme.textTheme.bodyMedium?.copyWith(
-                                    color: colorScheme.onSurface.withOpacity(
-                                      0.5,
+                                    color: colorScheme.onSurface.withValues(
+                                      alpha: 0.5,
                                     ),
                                   ),
                                 ),
@@ -202,8 +204,8 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                               return Card(
                                 margin: const EdgeInsets.only(bottom: 12),
                                 color: isCurrentTrack
-                                    ? colorScheme.primaryContainer.withOpacity(
-                                        0.3,
+                                    ? colorScheme.primaryContainer.withValues(
+                                        alpha: 0.3,
                                       )
                                     : null,
                                 child: ListTile(
@@ -256,7 +258,7 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                         style: theme.textTheme.bodyMedium
                                             ?.copyWith(
                                               color: colorScheme.onSurface
-                                                  .withOpacity(0.7),
+                                                  .withValues(alpha: 0.7),
                                             ),
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
@@ -268,7 +270,7 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                           style: theme.textTheme.bodySmall
                                               ?.copyWith(
                                                 color: colorScheme.onSurface
-                                                    .withOpacity(0.5),
+                                                    .withValues(alpha: 0.5),
                                               ),
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
@@ -283,7 +285,7 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                               style: theme.textTheme.bodySmall
                                                   ?.copyWith(
                                                     color: colorScheme.onSurface
-                                                        .withOpacity(0.5),
+                                                        .withValues(alpha: 0.5),
                                                   ),
                                             ),
                                             const SizedBox(width: 8),
@@ -292,7 +294,7 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                               style: theme.textTheme.bodySmall
                                                   ?.copyWith(
                                                     color: colorScheme.onSurface
-                                                        .withOpacity(0.5),
+                                                        .withValues(alpha: 0.5),
                                                   ),
                                             ),
                                             const SizedBox(width: 8),
@@ -314,7 +316,9 @@ class _MusicLibraryScreenState extends State<MusicLibraryScreen> {
                                                         ?.copyWith(
                                                           color: colorScheme
                                                               .onSurface
-                                                              .withOpacity(0.5),
+                                                              .withValues(
+                                                                alpha: 0.5,
+                                                              ),
                                                         ),
                                                   );
                                                 }

--- a/lib/screens/otp_screen.dart
+++ b/lib/screens/otp_screen.dart
@@ -100,10 +100,12 @@ class _OTPScreenState extends State<OTPScreen>
           // Проверяем наличие REGISTER токена
           if (tokenAttrs != null && tokenAttrs['REGISTER'] != null) {
             registerToken = tokenAttrs['REGISTER']['token']?.toString();
-            print('Найден REGISTER токен: ${registerToken?.substring(0, 20)}...');
-            
+            print(
+              'Найден REGISTER токен: ${registerToken?.substring(0, 20)}...',
+            );
+
             SchedulerBinding.instance.addPostFrameCallback((_) {
-              if (mounted) { 
+              if (mounted) {
                 setState(() => _isLoading = false);
                 Navigator.of(context).pushReplacement(
                   MaterialPageRoute(
@@ -271,19 +273,24 @@ class _OTPScreenState extends State<OTPScreen>
   void _handleIncorrectCode() {
     if (_isShowingError) return;
     _isShowingError = true;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: const Text('Неверный код. Попробуйте снова.'),
-        backgroundColor: Theme.of(context).colorScheme.error,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        behavior: SnackBarBehavior.floating,
-        margin: const EdgeInsets.all(10),
-      ),
-    ).closed.then((_) {
-      if (mounted) {
-        _isShowingError = false;
-      }
-    });
+    ScaffoldMessenger.of(context)
+        .showSnackBar(
+          SnackBar(
+            content: const Text('Неверный код. Попробуйте снова.'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            behavior: SnackBarBehavior.floating,
+            margin: const EdgeInsets.all(10),
+          ),
+        )
+        .closed
+        .then((_) {
+          if (mounted) {
+            _isShowingError = false;
+          }
+        });
     _pinController.clear();
     _pinFocusNode.requestFocus();
   }
@@ -304,7 +311,10 @@ class _OTPScreenState extends State<OTPScreen>
       decoration: BoxDecoration(
         color: colors.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2), width: 1),
+        border: Border.all(
+          color: colors.outline.withValues(alpha: 0.2),
+          width: 1,
+        ),
       ),
     );
 
@@ -383,7 +393,7 @@ class _OTPScreenState extends State<OTPScreen>
                                 ),
                                 borderRadius: BorderRadius.circular(20),
                                 border: Border.all(
-                                  color: colors.outline.withOpacity(0.2),
+                                  color: colors.outline.withValues(alpha: 0.2),
                                   width: 1,
                                 ),
                               ),
@@ -397,7 +407,7 @@ class _OTPScreenState extends State<OTPScreen>
                                         padding: const EdgeInsets.all(12),
                                         decoration: BoxDecoration(
                                           color: colors.primaryContainer
-                                              .withOpacity(0.5),
+                                              .withValues(alpha: 0.5),
                                           borderRadius: BorderRadius.circular(
                                             12,
                                           ),
@@ -471,7 +481,8 @@ class _OTPScreenState extends State<OTPScreen>
                                       ),
                                       onCompleted: (pin) => _verifyCode(pin),
                                       onChanged: (value) {
-                                        if (_isShowingError && value.isNotEmpty) {
+                                        if (_isShowingError &&
+                                            value.isNotEmpty) {
                                           _isShowingError = false;
                                         }
                                       },
@@ -485,10 +496,10 @@ class _OTPScreenState extends State<OTPScreen>
                               padding: const EdgeInsets.all(20),
                               decoration: BoxDecoration(
                                 color: colors.surfaceContainerHighest
-                                    .withOpacity(0.5),
+                                    .withValues(alpha: 0.5),
                                 borderRadius: BorderRadius.circular(16),
                                 border: Border.all(
-                                  color: colors.outline.withOpacity(0.2),
+                                  color: colors.outline.withValues(alpha: 0.2),
                                 ),
                               ),
                               child: Row(
@@ -522,7 +533,7 @@ class _OTPScreenState extends State<OTPScreen>
               ),
               if (_isLoading)
                 Container(
-                  color: Colors.black.withOpacity(0.5),
+                  color: Colors.black.withValues(alpha: 0.5),
                   child: Center(
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/password_auth_screen.dart
+++ b/lib/screens/password_auth_screen.dart
@@ -245,7 +245,7 @@ class _PasswordAuthScreenState extends State<PasswordAuthScreen> {
                         color: colors.surfaceContainerHighest,
                         borderRadius: BorderRadius.circular(12),
                         border: Border.all(
-                          color: colors.outline.withOpacity(0.2),
+                          color: colors.outline.withValues(alpha: 0.2),
                         ),
                       ),
                       child: Column(
@@ -332,7 +332,7 @@ class _PasswordAuthScreenState extends State<PasswordAuthScreen> {
 
           if (_isLoading)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(child: CircularProgressIndicator()),
             ),
         ],

--- a/lib/screens/password_management_screen.dart
+++ b/lib/screens/password_management_screen.dart
@@ -249,7 +249,7 @@ class _PasswordManagementScreenState extends State<PasswordManagementScreen> {
                 Container(
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: colors.primaryContainer.withOpacity(0.3),
+                    color: colors.primaryContainer.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Column(
@@ -335,7 +335,9 @@ class _PasswordManagementScreenState extends State<PasswordManagementScreen> {
                   decoration: BoxDecoration(
                     color: colors.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: colors.outline.withOpacity(0.3)),
+                    border: Border.all(
+                      color: colors.outline.withValues(alpha: 0.3),
+                    ),
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -407,7 +409,7 @@ class _PasswordManagementScreenState extends State<PasswordManagementScreen> {
           ),
           if (_isLoading)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(child: CircularProgressIndicator()),
             ),
         ],

--- a/lib/screens/phone_entry_screen.dart
+++ b/lib/screens/phone_entry_screen.dart
@@ -403,7 +403,9 @@ class _PhoneEntryScreenState extends State<PhoneEntryScreen>
                           padding: const EdgeInsets.all(16),
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
-                            color: colors.primaryContainer.withOpacity(0.5),
+                            color: colors.primaryContainer.withValues(
+                              alpha: 0.5,
+                            ),
                           ),
                           child: const Image(
                             image: AssetImage('assets/images/komet_512.png'),
@@ -524,7 +526,7 @@ class _PhoneEntryScreenState extends State<PhoneEntryScreen>
               ),
               if (_isLoading)
                 Container(
-                  color: Colors.black.withOpacity(0.5),
+                  color: Colors.black.withValues(alpha: 0.5),
                   child: Center(
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -588,7 +590,10 @@ class _PhoneInputCard extends StatelessWidget {
           colors: [colors.surfaceContainerHighest, colors.surfaceContainer],
         ),
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colors.outline.withOpacity(0.2), width: 1),
+        border: Border.all(
+          color: colors.outline.withValues(alpha: 0.2),
+          width: 1,
+        ),
       ),
       padding: const EdgeInsets.all(24),
       child: Column(
@@ -738,9 +743,9 @@ class _TosCheckbox extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: colors.surfaceContainerHighest.withOpacity(0.5),
+        color: colors.surfaceContainerHighest.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: Row(
@@ -830,8 +835,8 @@ class _SettingsButton extends StatelessWidget {
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
               color: hasAnySettings
-                  ? colors.primary.withOpacity(0.3)
-                  : colors.outline.withOpacity(0.2),
+                  ? colors.primary.withValues(alpha: 0.3)
+                  : colors.outline.withValues(alpha: 0.2),
               width: hasAnySettings ? 2 : 1,
             ),
           ),
@@ -845,7 +850,7 @@ class _SettingsButton extends StatelessWidget {
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
                       color: hasAnySettings
-                          ? colors.primary.withOpacity(0.15)
+                          ? colors.primary.withValues(alpha: 0.15)
                           : colors.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(12),
                     ),
@@ -883,7 +888,7 @@ class _SettingsButton extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: colors.primary.withOpacity(0.1),
+                    color: colors.primary.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -975,7 +980,7 @@ class _FooterText extends StatelessWidget {
       TextSpan(
         style: GoogleFonts.manrope(
           textStyle: textTheme.bodySmall,
-          color: colors.onSurfaceVariant.withOpacity(0.7),
+          color: colors.onSurfaceVariant.withValues(alpha: 0.7),
         ),
         children: [
           const TextSpan(

--- a/lib/screens/registration_screen.dart
+++ b/lib/screens/registration_screen.dart
@@ -66,15 +66,17 @@ class _RegistrationScreenState extends State<RegistrationScreen>
     _apiSubscription = ApiService.instance.messages.listen((message) {
       if (message['opcode'] == 23 && mounted && !_isNavigating) {
         _isNavigating = true;
-        print('Получен ответ opcode 23 (регистрация), полное сообщение: $message');
-        
+        print(
+          'Получен ответ opcode 23 (регистрация), полное сообщение: $message',
+        );
+
         final payload = message['payload'];
         print('Payload при регистрации: $payload');
 
         if (payload != null && payload['error'] != null) {
           final error = payload['error'];
           print('Ошибка регистрации: $error');
-          
+
           SchedulerBinding.instance.addPostFrameCallback((_) {
             if (mounted) {
               setState(() {
@@ -104,20 +106,24 @@ class _RegistrationScreenState extends State<RegistrationScreen>
           finalToken = payload['token'];
           userId = payload['userId']?.toString();
         }
-        
+
         if (finalToken == null && message['token'] != null) {
           finalToken = message['token']?.toString();
         }
         if (userId == null && message['userId'] != null) {
           userId = message['userId']?.toString();
         }
-        
+
         if (finalToken != null) {
-          print('Найден токен регистрации: ${finalToken.substring(0, 20)}..., UserID: $userId');
+          print(
+            'Найден токен регистрации: ${finalToken.substring(0, 20)}..., UserID: $userId',
+          );
         }
 
         if (finalToken != null) {
-          print('Успешная регистрация! Токен: ${finalToken.substring(0, 20)}..., UserID: $userId');
+          print(
+            'Успешная регистрация! Токен: ${finalToken.substring(0, 20)}..., UserID: $userId',
+          );
 
           SchedulerBinding.instance.addPostFrameCallback((_) async {
             if (!mounted) return;
@@ -169,7 +175,9 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                 setState(() => _isLoading = false);
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
-                    content: const Text('Регистрация завершена! Добро пожаловать!'),
+                    content: const Text(
+                      'Регистрация завершена! Добро пожаловать!',
+                    ),
                     backgroundColor: Colors.green,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),
@@ -373,7 +381,7 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                                 ),
                                 borderRadius: BorderRadius.circular(20),
                                 border: Border.all(
-                                  color: colors.outline.withOpacity(0.2),
+                                  color: colors.outline.withValues(alpha: 0.2),
                                   width: 1,
                                 ),
                               ),
@@ -387,8 +395,10 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                                         padding: const EdgeInsets.all(12),
                                         decoration: BoxDecoration(
                                           color: colors.primaryContainer
-                                              .withOpacity(0.5),
-                                          borderRadius: BorderRadius.circular(12),
+                                              .withValues(alpha: 0.5),
+                                          borderRadius: BorderRadius.circular(
+                                            12,
+                                          ),
                                         ),
                                         child: Icon(
                                           Icons.person_add_outlined,
@@ -428,14 +438,17 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                                     controller: _firstNameController,
                                     focusNode: _firstNameFocusNode,
                                     autofocus: true,
-                                    textCapitalization: TextCapitalization.words,
+                                    textCapitalization:
+                                        TextCapitalization.words,
                                     style: GoogleFonts.manrope(
                                       textStyle: textTheme.titleMedium,
                                       fontWeight: FontWeight.w600,
                                     ),
                                     decoration: InputDecoration(
                                       hintText: 'Введите ваше имя',
-                                      prefixIcon: const Icon(Icons.person_outline),
+                                      prefixIcon: const Icon(
+                                        Icons.person_outline,
+                                      ),
                                       border: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(16),
                                       ),
@@ -458,15 +471,17 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                                   TextFormField(
                                     controller: _lastNameController,
                                     focusNode: _lastNameFocusNode,
-                                    textCapitalization: TextCapitalization.words,
+                                    textCapitalization:
+                                        TextCapitalization.words,
                                     style: GoogleFonts.manrope(
                                       textStyle: textTheme.titleMedium,
                                       fontWeight: FontWeight.w600,
                                     ),
                                     decoration: InputDecoration(
                                       hintText: 'Введите вашу фамилию',
-                                      prefixIcon:
-                                          const Icon(Icons.person_outline),
+                                      prefixIcon: const Icon(
+                                        Icons.person_outline,
+                                      ),
                                       border: OutlineInputBorder(
                                         borderRadius: BorderRadius.circular(16),
                                       ),
@@ -486,11 +501,11 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                             Container(
                               padding: const EdgeInsets.all(20),
                               decoration: BoxDecoration(
-                                color:
-                                    colors.surfaceContainerHighest.withOpacity(0.5),
+                                color: colors.surfaceContainerHighest
+                                    .withValues(alpha: 0.5),
                                 borderRadius: BorderRadius.circular(16),
                                 border: Border.all(
-                                  color: colors.outline.withOpacity(0.2),
+                                  color: colors.outline.withValues(alpha: 0.2),
                                 ),
                               ),
                               child: Row(
@@ -543,7 +558,7 @@ class _RegistrationScreenState extends State<RegistrationScreen>
               ),
               if (_isLoading)
                 Container(
-                  color: Colors.black.withOpacity(0.5),
+                  color: Colors.black.withValues(alpha: 0.5),
                   child: Center(
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/search_channels_screen.dart
+++ b/lib/screens/search_channels_screen.dart
@@ -170,7 +170,7 @@ class _SearchChannelsScreenState extends State<SearchChannelsScreen> {
                 Container(
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: colors.primaryContainer.withOpacity(0.3),
+                    color: colors.primaryContainer.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Column(
@@ -229,7 +229,9 @@ class _SearchChannelsScreenState extends State<SearchChannelsScreen> {
                   decoration: BoxDecoration(
                     color: colors.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: colors.outline.withOpacity(0.3)),
+                    border: Border.all(
+                      color: colors.outline.withValues(alpha: 0.3),
+                    ),
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -313,9 +315,11 @@ class _SearchChannelsScreenState extends State<SearchChannelsScreen> {
                   Container(
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: Colors.orange.withOpacity(0.1),
+                      color: Colors.orange.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: Colors.orange.withOpacity(0.3)),
+                      border: Border.all(
+                        color: Colors.orange.withValues(alpha: 0.3),
+                      ),
                     ),
                     child: Row(
                       children: [
@@ -339,7 +343,7 @@ class _SearchChannelsScreenState extends State<SearchChannelsScreen> {
           ),
           if (_isLoading)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(child: CircularProgressIndicator()),
             ),
         ],
@@ -809,10 +813,10 @@ class _ChannelDetailsScreenState extends State<ChannelDetailsScreen> {
                   Container(
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: colors.primaryContainer.withOpacity(0.3),
+                      color: colors.primaryContainer.withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(12),
                       border: Border.all(
-                        color: colors.primary.withOpacity(0.3),
+                        color: colors.primary.withValues(alpha: 0.3),
                       ),
                     ),
                     child: Column(
@@ -876,9 +880,11 @@ class _ChannelDetailsScreenState extends State<ChannelDetailsScreen> {
                   Container(
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: Colors.red.withOpacity(0.1),
+                      color: Colors.red.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: Colors.red.withOpacity(0.3)),
+                      border: Border.all(
+                        color: Colors.red.withValues(alpha: 0.3),
+                      ),
                     ),
                     child: Row(
                       children: [
@@ -902,7 +908,7 @@ class _ChannelDetailsScreenState extends State<ChannelDetailsScreen> {
           ),
           if (_isLoading)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(child: CircularProgressIndicator()),
             ),
         ],

--- a/lib/screens/search_contact_screen.dart
+++ b/lib/screens/search_contact_screen.dart
@@ -315,7 +315,7 @@ class _SearchContactScreenState extends State<SearchContactScreen> {
                 Container(
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: colors.primaryContainer.withOpacity(0.3),
+                    color: colors.primaryContainer.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Column(
@@ -373,7 +373,9 @@ class _SearchContactScreenState extends State<SearchContactScreen> {
                   decoration: BoxDecoration(
                     color: colors.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: colors.outline.withOpacity(0.3)),
+                    border: Border.all(
+                      color: colors.outline.withValues(alpha: 0.3),
+                    ),
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -443,9 +445,11 @@ class _SearchContactScreenState extends State<SearchContactScreen> {
                   Container(
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: Colors.green.withOpacity(0.1),
+                      color: Colors.green.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: Colors.green.withOpacity(0.3)),
+                      border: Border.all(
+                        color: Colors.green.withValues(alpha: 0.3),
+                      ),
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -554,9 +558,11 @@ class _SearchContactScreenState extends State<SearchContactScreen> {
                   Container(
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
-                      color: Colors.orange.withOpacity(0.1),
+                      color: Colors.orange.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: Colors.orange.withOpacity(0.3)),
+                      border: Border.all(
+                        color: Colors.orange.withValues(alpha: 0.3),
+                      ),
                     ),
                     child: Row(
                       children: [
@@ -580,7 +586,7 @@ class _SearchContactScreenState extends State<SearchContactScreen> {
           ),
           if (_isLoading)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(child: CircularProgressIndicator()),
             ),
         ],

--- a/lib/screens/settings/about_screen.dart
+++ b/lib/screens/settings/about_screen.dart
@@ -157,7 +157,7 @@ class AboutScreen extends StatelessWidget {
                 'Версия $appVersion',
                 style: TextStyle(
                   fontSize: 16,
-                  color: colors.onSurface.withOpacity(0.7),
+                  color: colors.onSurface.withValues(alpha: 0.7),
                 ),
               ),
             ],
@@ -167,7 +167,7 @@ class AboutScreen extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: colors.surfaceContainerHighest.withOpacity(0.3),
+              color: colors.surfaceContainerHighest.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Column(
@@ -185,7 +185,7 @@ class AboutScreen extends StatelessWidget {
                 Text(
                   'Мы — команда энтузиастов, создавшая Komet. Нас объединила страсть к технологиям и желание дать пользователям свободу выбора.',
                   style: TextStyle(
-                    color: colors.onSurface.withOpacity(0.8),
+                    color: colors.onSurface.withValues(alpha: 0.8),
                     height: 1.5,
                   ),
                 ),
@@ -266,7 +266,7 @@ class AboutScreen extends StatelessWidget {
                 Text(
                   'Мы верим в открытость, прозрачность и право пользователей на выбор. Komet — это наш ответ излишним ограничениям.',
                   style: TextStyle(
-                    color: colors.onSurface.withOpacity(0.8),
+                    color: colors.onSurface.withValues(alpha: 0.8),
                     height: 1.5,
                   ),
                 ),
@@ -279,7 +279,7 @@ class AboutScreen extends StatelessWidget {
                     child: RichText(
                       text: TextSpan(
                         style: TextStyle(
-                          color: colors.onSurface.withOpacity(0.8),
+                          color: colors.onSurface.withValues(alpha: 0.8),
                           height: 1.5,
                         ),
                         children: [
@@ -305,7 +305,7 @@ class AboutScreen extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: colors.surfaceContainerHighest.withOpacity(0.3),
+              color: colors.surfaceContainerHighest.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Column(

--- a/lib/screens/settings/animations_screen.dart
+++ b/lib/screens/settings/animations_screen.dart
@@ -193,7 +193,9 @@ class _ModernSection extends StatelessWidget {
           elevation: 0,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
-            side: BorderSide(color: colors.outlineVariant.withOpacity(0.3)),
+            side: BorderSide(
+              color: colors.outlineVariant.withValues(alpha: 0.3),
+            ),
           ),
           clipBehavior: Clip.antiAlias,
           child: Padding(

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -254,9 +254,9 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen>
         Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: colors.surfaceContainerHighest.withOpacity(0.5),
+            color: colors.surfaceContainerHighest.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: colors.outline.withOpacity(0.2)),
+            border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
           ),
           child: Row(
             children: [
@@ -310,7 +310,7 @@ class _AppearanceCard extends StatelessWidget {
             gradient: gradient,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -323,7 +323,7 @@ class _AppearanceCard extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: colors.primaryContainer.withOpacity(0.5),
+                      color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Icon(icon, color: colors.primary, size: 24),

--- a/lib/screens/settings/auth_settings_screen.dart
+++ b/lib/screens/settings/auth_settings_screen.dart
@@ -217,12 +217,12 @@ class _AuthSettingsScreenState extends State<AuthSettingsScreen>
                         Container(
                           padding: const EdgeInsets.all(20),
                           decoration: BoxDecoration(
-                            color: colors.surfaceContainerHighest.withOpacity(
-                              0.5,
+                            color: colors.surfaceContainerHighest.withValues(
+                              alpha: 0.5,
                             ),
                             borderRadius: BorderRadius.circular(16),
                             border: Border.all(
-                              color: colors.outline.withOpacity(0.2),
+                              color: colors.outline.withValues(alpha: 0.2),
                             ),
                           ),
                           child: Row(
@@ -292,14 +292,14 @@ class _SettingsCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
               color: isConfigured
-                  ? colors.primary.withOpacity(0.3)
-                  : colors.outline.withOpacity(0.2),
+                  ? colors.primary.withValues(alpha: 0.3)
+                  : colors.outline.withValues(alpha: 0.2),
               width: isConfigured ? 2 : 1,
             ),
             boxShadow: isConfigured
                 ? [
                     BoxShadow(
-                      color: colors.primary.withOpacity(0.1),
+                      color: colors.primary.withValues(alpha: 0.1),
                       blurRadius: 20,
                       offset: const Offset(0, 4),
                     ),
@@ -316,7 +316,7 @@ class _SettingsCard extends StatelessWidget {
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
                       color: isConfigured
-                          ? colors.primary.withOpacity(0.15)
+                          ? colors.primary.withValues(alpha: 0.15)
                           : colors.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(12),
                     ),
@@ -336,7 +336,7 @@ class _SettingsCard extends StatelessWidget {
                         vertical: 6,
                       ),
                       decoration: BoxDecoration(
-                        color: colors.primary.withOpacity(0.15),
+                        color: colors.primary.withValues(alpha: 0.15),
                         borderRadius: BorderRadius.circular(20),
                       ),
                       child: Row(

--- a/lib/screens/settings/bypass_screen.dart
+++ b/lib/screens/settings/bypass_screen.dart
@@ -73,7 +73,9 @@ class _BypassScreenState extends State<BypassScreen> {
                 decoration: BoxDecoration(
                   color: colors.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: colors.outline.withOpacity(0.2)),
+                  border: Border.all(
+                    color: colors.outline.withValues(alpha: 0.2),
+                  ),
                 ),
                 child: Row(
                   children: [
@@ -114,7 +116,7 @@ class _BypassScreenState extends State<BypassScreen> {
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: colors.primaryContainer.withOpacity(0.3),
+                color: colors.primaryContainer.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Column(
@@ -181,7 +183,9 @@ class _BypassScreenState extends State<BypassScreen> {
               decoration: BoxDecoration(
                 color: colors.surfaceContainerHighest,
                 borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: colors.outline.withOpacity(0.3)),
+                border: Border.all(
+                  color: colors.outline.withValues(alpha: 0.3),
+                ),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -220,7 +224,9 @@ class _BypassScreenState extends State<BypassScreen> {
               decoration: BoxDecoration(
                 color: colors.surfaceContainerHighest,
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: colors.outline.withOpacity(0.25)),
+                border: Border.all(
+                  color: colors.outline.withValues(alpha: 0.25),
+                ),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -254,7 +260,7 @@ class _BypassScreenState extends State<BypassScreen> {
                       color: colors.surface,
                       borderRadius: BorderRadius.circular(8),
                       border: Border.all(
-                        color: colors.outline.withOpacity(0.3),
+                        color: colors.outline.withValues(alpha: 0.3),
                       ),
                     ),
                     child: Column(
@@ -350,8 +356,8 @@ class _BypassScreenState extends State<BypassScreen> {
                             vertical: 8,
                           ),
                           decoration: BoxDecoration(
-                            color: colors.surfaceContainerHighest.withOpacity(
-                              0.6,
+                            color: colors.surfaceContainerHighest.withValues(
+                              alpha: 0.6,
                             ),
                             borderRadius: BorderRadius.circular(12),
                           ),
@@ -536,7 +542,7 @@ class _BypassScreenState extends State<BypassScreen> {
             child: Container(
               width: double.infinity,
               height: double.infinity,
-              color: Colors.black.withOpacity(0.3),
+              color: Colors.black.withValues(alpha: 0.3),
             ),
           ),
 
@@ -550,7 +556,7 @@ class _BypassScreenState extends State<BypassScreen> {
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.3),
+                    color: Colors.black.withValues(alpha: 0.3),
                     blurRadius: 20,
                     offset: const Offset(0, 10),
                   ),
@@ -599,10 +605,12 @@ class _BypassScreenState extends State<BypassScreen> {
                         Container(
                           padding: const EdgeInsets.all(16),
                           decoration: BoxDecoration(
-                            color: colors.primaryContainer.withOpacity(0.3),
+                            color: colors.primaryContainer.withValues(
+                              alpha: 0.3,
+                            ),
                             borderRadius: BorderRadius.circular(12),
                             border: Border.all(
-                              color: colors.outline.withOpacity(0.3),
+                              color: colors.outline.withValues(alpha: 0.3),
                             ),
                           ),
                           child: Column(
@@ -629,7 +637,9 @@ class _BypassScreenState extends State<BypassScreen> {
                               Text(
                                 "Эта функция предназначена для обхода ограничений и блокировок. Используйте с осторожностью и только в законных целях.",
                                 style: TextStyle(
-                                  color: colors.onSurface.withOpacity(0.8),
+                                  color: colors.onSurface.withValues(
+                                    alpha: 0.8,
+                                  ),
                                   fontSize: 14,
                                 ),
                               ),

--- a/lib/screens/settings/chat_notification_settings_dialog.dart
+++ b/lib/screens/settings/chat_notification_settings_dialog.dart
@@ -142,23 +142,26 @@ class _ChatNotificationSettingsDialogState
         return SimpleDialog(
           title: const Text('Вибрация'),
           children: [
-            RadioListTile<VibrationMode>(
-              title: const Text('Без вибрации'),
-              value: VibrationMode.none,
+            RadioGroup<VibrationMode>(
               groupValue: _vibrationMode,
               onChanged: (v) => Navigator.of(context).pop(v),
-            ),
-            RadioListTile<VibrationMode>(
-              title: const Text('Короткая'),
-              value: VibrationMode.short,
-              groupValue: _vibrationMode,
-              onChanged: (v) => Navigator.of(context).pop(v),
-            ),
-            RadioListTile<VibrationMode>(
-              title: const Text('Длинная'),
-              value: VibrationMode.long,
-              groupValue: _vibrationMode,
-              onChanged: (v) => Navigator.of(context).pop(v),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  RadioListTile<VibrationMode>(
+                    title: const Text('Без вибрации'),
+                    value: VibrationMode.none,
+                  ),
+                  RadioListTile<VibrationMode>(
+                    title: const Text('Короткая'),
+                    value: VibrationMode.short,
+                  ),
+                  RadioListTile<VibrationMode>(
+                    title: const Text('Длинная'),
+                    value: VibrationMode.long,
+                  ),
+                ],
+              ),
             ),
           ],
         );

--- a/lib/screens/settings/chat_notification_settings_dialog.dart
+++ b/lib/screens/settings/chat_notification_settings_dialog.dart
@@ -24,7 +24,7 @@ class ChatNotificationSettingsDialog extends StatefulWidget {
 class _ChatNotificationSettingsDialogState
     extends State<ChatNotificationSettingsDialog> {
   final _settingsService = NotificationSettingsService();
-  
+
   bool _isLoading = true;
   bool _hasException = false;
   bool _notificationsEnabled = true;
@@ -126,7 +126,9 @@ class _ChatNotificationSettingsDialogState
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Исключение удалено, используются настройки по умолчанию'),
+          content: Text(
+            'Исключение удалено, используются настройки по умолчанию',
+          ),
           backgroundColor: Colors.green,
         ),
       );

--- a/lib/screens/settings/customization_screen.dart
+++ b/lib/screens/settings/customization_screen.dart
@@ -73,7 +73,6 @@ class _CustomizationScreenState extends State<CustomizationScreen> {
   late bool _useGradientForAddAccountButton;
   late bool _useGlassPanels;
 
-
   @override
   void initState() {
     super.initState();
@@ -85,7 +84,6 @@ class _CustomizationScreenState extends State<CustomizationScreen> {
     _useGradientForAddAccountButton = theme.useGradientForAddAccountButton;
     _useGlassPanels = theme.useGlassPanels;
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -120,27 +118,27 @@ class _CustomizationScreenState extends State<CustomizationScreen> {
         : const Color(0xFF464646);
 
     return Scaffold(
-          appBar: AppBar(
-            title: const Text("Персонализация"),
-            surfaceTintColor: Colors.transparent,
-            backgroundColor: colors.surface,
-            elevation: 0,
-          ),
-          body: ListView(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      appBar: AppBar(
+        title: const Text("Персонализация"),
+        surfaceTintColor: Colors.transparent,
+        backgroundColor: colors.surface,
+        elevation: 0,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        children: [
+          _MessagePreviewSection(isMaterialYou: _isMaterialYou),
+          const SizedBox(height: 16),
+          const _ThemeManagementSection(),
+          const SizedBox(height: 16),
+          _ModernSection(
+            title: "Тема приложения",
             children: [
-              _MessagePreviewSection(isMaterialYou: _isMaterialYou),
-              const SizedBox(height: 16),
-              const _ThemeManagementSection(),
-              const SizedBox(height: 16),
-              _ModernSection(
-                title: "Тема приложения",
-                children: [
-                  const SizedBox(height: 8),
-                  _CustomSettingTile(
-                    icon: Icons.auto_awesome_outlined,
-                    title: "Material You",
-                    subtitle: "Использовать цвета системы (Android 12+)",
+              const SizedBox(height: 8),
+              _CustomSettingTile(
+                icon: Icons.auto_awesome_outlined,
+                title: "Material You",
+                subtitle: "Использовать цвета системы (Android 12+)",
                 child: Switch(
                   value: _isMaterialYou,
                   onChanged: (value) {
@@ -148,8 +146,8 @@ class _CustomizationScreenState extends State<CustomizationScreen> {
                     theme.setMaterialYouEnabled(value);
                   },
                 ),
-                  ),
-                  const SizedBox(height: 12),
+              ),
+              const SizedBox(height: 12),
               IgnorePointer(
                 ignoring: _isMaterialYou,
                 child: Opacity(
@@ -755,13 +753,13 @@ class _CustomizationScreenState extends State<CustomizationScreen> {
                 icon: Icons.person_add,
                 title: "Градиент для кнопки добавления аккаунта",
                 subtitle: "Применить градиент к кнопке в drawer",
-                    child: Switch(
-                      value: _useGradientForAddAccountButton,
-                      onChanged: (value) {
-                        setState(() => _useGradientForAddAccountButton = value);
-                        theme.setUseGradientForAddAccountButton(value);
-                      },
-                    ),
+                child: Switch(
+                  value: _useGradientForAddAccountButton,
+                  onChanged: (value) {
+                    setState(() => _useGradientForAddAccountButton = value);
+                    theme.setUseGradientForAddAccountButton(value);
+                  },
+                ),
               ),
               if (theme.useGradientForAddAccountButton) ...[
                 const SizedBox(height: 16),
@@ -1210,13 +1208,13 @@ class _ThemeManagementSection extends StatelessWidget {
             margin: const EdgeInsets.only(bottom: 8),
             elevation: 0,
             color: isActive
-                ? colors.primaryContainer.withOpacity(0.3)
-                : colors.surfaceContainerHighest.withOpacity(0.2),
+                ? colors.primaryContainer.withValues(alpha: 0.3)
+                : colors.surfaceContainerHighest.withValues(alpha: 0.2),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(16),
               side: BorderSide(
                 color: isActive
-                    ? colors.primary.withOpacity(0.5)
+                    ? colors.primary.withValues(alpha: 0.5)
                     : Colors.transparent,
                 width: 2,
               ),
@@ -1360,12 +1358,12 @@ class _ModernSection extends StatelessWidget {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(20),
             side: BorderSide(
-              color: colors.outlineVariant.withOpacity(0.2),
+              color: colors.outlineVariant.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
           clipBehavior: Clip.antiAlias,
-          color: colors.surfaceContainerHighest.withOpacity(0.3),
+          color: colors.surfaceContainerHighest.withValues(alpha: 0.3),
           child: Padding(
             padding: const EdgeInsets.symmetric(
               horizontal: 16.0,
@@ -1402,7 +1400,7 @@ class _CustomSettingTile extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
-              color: colors.primaryContainer.withOpacity(0.3),
+              color: colors.primaryContainer.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Icon(icon, color: colors.primary, size: 20),
@@ -1472,7 +1470,7 @@ class _ColorPickerTile extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: colors.primaryContainer.withOpacity(0.3),
+                color: colors.primaryContainer.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Icon(
@@ -1512,12 +1510,12 @@ class _ColorPickerTile extends StatelessWidget {
                 color: color,
                 shape: BoxShape.circle,
                 border: Border.all(
-                  color: colors.outline.withOpacity(0.3),
+                  color: colors.outline.withValues(alpha: 0.3),
                   width: 2,
                 ),
                 boxShadow: [
                   BoxShadow(
-                    color: color.withOpacity(0.3),
+                    color: color.withValues(alpha: 0.3),
                     blurRadius: 8,
                     offset: const Offset(0, 2),
                   ),
@@ -1582,7 +1580,7 @@ class _SliderTile extends StatelessWidget {
                   vertical: 4,
                 ),
                 decoration: BoxDecoration(
-                  color: colors.primaryContainer.withOpacity(0.5),
+                  color: colors.primaryContainer.withValues(alpha: 0.5),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Text(
@@ -1695,7 +1693,7 @@ class _MessagePreviewSection extends StatelessWidget {
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outlineVariant.withOpacity(0.2),
+              color: colors.outlineVariant.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -1714,8 +1712,8 @@ class _MessagePreviewSection extends StatelessWidget {
                         ),
                         child: Container(
                           height: 40,
-                          color: colors.surface.withOpacity(
-                            theme.topBarOpacity,
+                          color: colors.surface.withValues(
+                            alpha: theme.topBarOpacity,
                           ),
                           child: Row(
                             children: [
@@ -1788,8 +1786,8 @@ class _MessagePreviewSection extends StatelessWidget {
                         ),
                         child: Container(
                           height: 40,
-                          color: colors.surface.withOpacity(
-                            theme.bottomBarOpacity,
+                          color: colors.surface.withValues(
+                            alpha: theme.bottomBarOpacity,
                           ),
                           child: Row(
                             children: [
@@ -1864,7 +1862,7 @@ class _ChatWallpaperPreview extends StatelessWidget {
                     sigmaX: theme.chatWallpaperImageBlur,
                     sigmaY: theme.chatWallpaperImageBlur,
                   ),
-                  child: Container(color: Colors.black.withOpacity(0.05)),
+                  child: Container(color: Colors.black.withValues(alpha: 0.05)),
                 ),
             ],
           );
@@ -2027,7 +2025,7 @@ class _VideoWallpaperState extends State<_VideoWallpaper> {
         ),
 
         Container(
-          decoration: BoxDecoration(color: Colors.black.withOpacity(0.3)),
+          decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.3)),
         ),
       ],
     );
@@ -2166,7 +2164,7 @@ class _ActionTile extends StatelessWidget {
                     (isDestructive
                             ? colors.errorContainer
                             : colors.primaryContainer)
-                        .withOpacity(0.3),
+                        .withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Icon(icon, color: iconColor, size: 20),

--- a/lib/screens/settings/customization_screen.dart
+++ b/lib/screens/settings/customization_screen.dart
@@ -1114,9 +1114,12 @@ class _ThemeManagementSection extends StatelessWidget {
           final tempFile = File('${tempDir.path}/$fileName');
           await tempFile.writeAsBytes(bytes);
 
-          final result = await Share.shareXFiles([
-            XFile(tempFile.path),
-          ], text: 'Экспорт темы: ${preset.name}');
+          final result = await SharePlus.instance.share(
+            ShareParams(
+              text: 'Экспорт темы: ${preset.name}',
+              files: [XFile(tempFile.path)],
+            ),
+          );
 
           if (context.mounted) {
             if (result.status == ShareResultStatus.success) {

--- a/lib/screens/settings/export_session_screen.dart
+++ b/lib/screens/settings/export_session_screen.dart
@@ -251,7 +251,7 @@ class _ExportSessionScreenState extends State<ExportSessionScreen> {
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: colors.errorContainer.withOpacity(0.3),
+                color: colors.errorContainer.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Row(

--- a/lib/screens/settings/komet_misc_screen.dart
+++ b/lib/screens/settings/komet_misc_screen.dart
@@ -451,9 +451,9 @@ class _KometMiscScreenState extends State<KometMiscScreen>
         Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: colors.surfaceContainerHighest.withOpacity(0.5),
+            color: colors.surfaceContainerHighest.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: colors.outline.withOpacity(0.2)),
+            border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
           ),
           child: Row(
             children: [
@@ -524,7 +524,7 @@ class _SettingCard extends StatelessWidget {
             gradient: gradient,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -537,7 +537,7 @@ class _SettingCard extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: colors.primaryContainer.withOpacity(0.5),
+                      color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Icon(icon, color: colors.primary, size: 24),
@@ -549,7 +549,7 @@ class _SettingCard extends StatelessWidget {
                       vertical: 6,
                     ),
                     decoration: BoxDecoration(
-                      color: statusColor.withOpacity(0.15),
+                      color: statusColor.withValues(alpha: 0.15),
                       borderRadius: BorderRadius.circular(20),
                     ),
                     child: Row(
@@ -647,7 +647,10 @@ class _ToggleCard extends StatelessWidget {
       decoration: BoxDecoration(
         gradient: gradient,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colors.outline.withOpacity(0.2), width: 1),
+        border: Border.all(
+          color: colors.outline.withValues(alpha: 0.2),
+          width: 1,
+        ),
       ),
       child: Material(
         color: Colors.transparent,
@@ -664,8 +667,8 @@ class _ToggleCard extends StatelessWidget {
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: value
-                        ? colors.primaryContainer.withOpacity(0.7)
-                        : colors.primaryContainer.withOpacity(0.3),
+                        ? colors.primaryContainer.withValues(alpha: 0.7)
+                        : colors.primaryContainer.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Icon(
@@ -692,8 +695,8 @@ class _ToggleCard extends StatelessWidget {
                         description,
                         style: GoogleFonts.manrope(
                           textStyle: textTheme.bodySmall,
-                          color: colors.onSurfaceVariant.withOpacity(
-                            isDisabled ? 0.5 : 1,
+                          color: colors.onSurfaceVariant.withValues(
+                            alpha: isDisabled ? 0.5 : 1,
                           ),
                           height: 1.3,
                         ),

--- a/lib/screens/settings/komet_misc_screen.dart
+++ b/lib/screens/settings/komet_misc_screen.dart
@@ -710,7 +710,7 @@ class _ToggleCard extends StatelessWidget {
                 Switch(
                   value: value,
                   onChanged: isDisabled ? null : onChanged,
-                  activeColor: colors.primary,
+                  activeThumbColor: colors.primary,
                   inactiveThumbColor: colors.outlineVariant,
                 ),
               ],

--- a/lib/screens/settings/network_screen.dart
+++ b/lib/screens/settings/network_screen.dart
@@ -200,13 +200,13 @@ class _NetworkScreenState extends State<NetworkScreen>
                   Icon(
                     Icons.wifi_off,
                     size: 64,
-                    color: colors.onSurface.withOpacity(0.3),
+                    color: colors.onSurface.withValues(alpha: 0.3),
                   ),
                   const SizedBox(height: 16),
                   Text(
                     'Не удалось загрузить статистику сети',
                     style: TextStyle(
-                      color: colors.onSurface.withOpacity(0.6),
+                      color: colors.onSurface.withValues(alpha: 0.6),
                       fontSize: 16,
                     ),
                   ),
@@ -259,7 +259,7 @@ class _NetworkScreenState extends State<NetworkScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Row(
         children: [
@@ -268,8 +268,8 @@ class _NetworkScreenState extends State<NetworkScreen>
             height: 60,
             decoration: BoxDecoration(
               color: stats.isConnected
-                  ? colors.primary.withOpacity(0.1)
-                  : colors.error.withOpacity(0.1),
+                  ? colors.primary.withValues(alpha: 0.1)
+                  : colors.error.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Icon(
@@ -296,7 +296,7 @@ class _NetworkScreenState extends State<NetworkScreen>
                   stats.connectionType,
                   style: TextStyle(
                     fontSize: 14,
-                    color: colors.onSurface.withOpacity(0.7),
+                    color: colors.onSurface.withValues(alpha: 0.7),
                   ),
                 ),
                 if (stats.isConnected) ...[
@@ -313,7 +313,7 @@ class _NetworkScreenState extends State<NetworkScreen>
                         '${stats.signalStrength}%',
                         style: TextStyle(
                           fontSize: 12,
-                          color: colors.onSurface.withOpacity(0.6),
+                          color: colors.onSurface.withValues(alpha: 0.6),
                         ),
                       ),
                     ],
@@ -344,7 +344,7 @@ class _NetworkScreenState extends State<NetworkScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Column(
         children: [
@@ -399,7 +399,7 @@ class _NetworkScreenState extends State<NetworkScreen>
                             'использовано',
                             style: TextStyle(
                               fontSize: 12,
-                              color: colors.onSurface.withOpacity(0.7),
+                              color: colors.onSurface.withValues(alpha: 0.7),
                             ),
                           ),
                         ],
@@ -477,7 +477,7 @@ class _NetworkScreenState extends State<NetworkScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -511,7 +511,7 @@ class _NetworkScreenState extends State<NetworkScreen>
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: colors.primary.withOpacity(0.1),
+                  color: colors.primary.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Text(
@@ -539,7 +539,7 @@ class _NetworkScreenState extends State<NetworkScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -607,7 +607,7 @@ class _NetworkScreenState extends State<NetworkScreen>
             width: 40,
             height: 40,
             decoration: BoxDecoration(
-              color: color.withOpacity(0.1),
+              color: color.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Icon(icon, color: color, size: 20),
@@ -630,7 +630,7 @@ class _NetworkScreenState extends State<NetworkScreen>
                   size,
                   style: TextStyle(
                     fontSize: 12,
-                    color: colors.onSurface.withOpacity(0.6),
+                    color: colors.onSurface.withValues(alpha: 0.6),
                   ),
                 ),
               ],
@@ -671,7 +671,7 @@ class _NetworkScreenState extends State<NetworkScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -705,7 +705,7 @@ class _NetworkScreenState extends State<NetworkScreen>
                       Container(
                         height: height * 100,
                         decoration: BoxDecoration(
-                          color: colors.primary.withOpacity(0.7),
+                          color: colors.primary.withValues(alpha: 0.7),
                           borderRadius: BorderRadius.circular(2),
                         ),
                       ),
@@ -714,7 +714,7 @@ class _NetworkScreenState extends State<NetworkScreen>
                         '${hourStats.hour}',
                         style: TextStyle(
                           fontSize: 10,
-                          color: colors.onSurface.withOpacity(0.6),
+                          color: colors.onSurface.withValues(alpha: 0.6),
                         ),
                       ),
                     ],

--- a/lib/screens/settings/network_settings_screen.dart
+++ b/lib/screens/settings/network_settings_screen.dart
@@ -269,10 +269,12 @@ class _NetworkSettingsScreenState extends State<NetworkSettingsScreen>
           decoration: BoxDecoration(
             color: Theme.of(
               context,
-            ).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
-              color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+              color: Theme.of(
+                context,
+              ).colorScheme.outline.withValues(alpha: 0.2),
             ),
           ),
           child: Row(
@@ -333,7 +335,7 @@ class _NetworkCard extends StatelessWidget {
             ),
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -346,7 +348,7 @@ class _NetworkCard extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: colors.primaryContainer.withOpacity(0.5),
+                      color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Icon(icon, color: colors.primary, size: 24),

--- a/lib/screens/settings/notification_settings_screen.dart
+++ b/lib/screens/settings/notification_settings_screen.dart
@@ -16,7 +16,7 @@ class NotificationSettingsScreen extends StatefulWidget {
 class _NotificationSettingsScreenState
     extends State<NotificationSettingsScreen> {
   bool _isLoading = false;
-  
+
   // Новые настройки
   bool _notificationsEnabled = true;
   bool _privateChatsEnabled = true;
@@ -24,7 +24,7 @@ class _NotificationSettingsScreenState
   bool _channelsEnabled = true;
   bool _reactionsEnabled = true;
   VibrationMode _vibrationMode = VibrationMode.short;
-  
+
   final _settingsService = NotificationSettingsService();
 
   Widget buildModalContent(BuildContext context) {
@@ -104,14 +104,18 @@ class _NotificationSettingsScreenState
                 ),
               ),
               const SizedBox(height: 16),
-              
+
               // Настройки по типу чата
               _OutlinedSection(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Padding(
-                      padding: const EdgeInsets.only(left: 8, top: 8, bottom: 4),
+                      padding: const EdgeInsets.only(
+                        left: 8,
+                        top: 8,
+                        bottom: 4,
+                      ),
                       child: Text(
                         'Уведомления из чатов',
                         style: TextStyle(
@@ -126,79 +130,91 @@ class _NotificationSettingsScreenState
                       secondary: const Icon(Icons.person_outline),
                       title: const Text("Личные чаты"),
                       value: _privateChatsEnabled,
-                      onChanged: _notificationsEnabled ? (value) async {
-                        await _settingsService.setPrivateChatsEnabled(value);
-                        setState(() => _privateChatsEnabled = value);
-                        if (mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Настройки обновлены'),
-                              backgroundColor: Colors.green,
-                            ),
-                          );
-                        }
-                      } : null,
+                      onChanged: _notificationsEnabled
+                          ? (value) async {
+                              await _settingsService.setPrivateChatsEnabled(
+                                value,
+                              );
+                              setState(() => _privateChatsEnabled = value);
+                              if (mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Настройки обновлены'),
+                                    backgroundColor: Colors.green,
+                                  ),
+                                );
+                              }
+                            }
+                          : null,
                     ),
                     SwitchListTile(
                       contentPadding: EdgeInsets.zero,
                       secondary: const Icon(Icons.group_outlined),
                       title: const Text("Группы"),
                       value: _groupsEnabled,
-                      onChanged: _notificationsEnabled ? (value) async {
-                        await _settingsService.setGroupsEnabled(value);
-                        setState(() => _groupsEnabled = value);
-                        if (mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Настройки обновлены'),
-                              backgroundColor: Colors.green,
-                            ),
-                          );
-                        }
-                      } : null,
+                      onChanged: _notificationsEnabled
+                          ? (value) async {
+                              await _settingsService.setGroupsEnabled(value);
+                              setState(() => _groupsEnabled = value);
+                              if (mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Настройки обновлены'),
+                                    backgroundColor: Colors.green,
+                                  ),
+                                );
+                              }
+                            }
+                          : null,
                     ),
                     SwitchListTile(
                       contentPadding: EdgeInsets.zero,
                       secondary: const Icon(Icons.campaign_outlined),
                       title: const Text("Каналы"),
                       value: _channelsEnabled,
-                      onChanged: _notificationsEnabled ? (value) async {
-                        await _settingsService.setChannelsEnabled(value);
-                        setState(() => _channelsEnabled = value);
-                        if (mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Настройки обновлены'),
-                              backgroundColor: Colors.green,
-                            ),
-                          );
-                        }
-                      } : null,
+                      onChanged: _notificationsEnabled
+                          ? (value) async {
+                              await _settingsService.setChannelsEnabled(value);
+                              setState(() => _channelsEnabled = value);
+                              if (mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Настройки обновлены'),
+                                    backgroundColor: Colors.green,
+                                  ),
+                                );
+                              }
+                            }
+                          : null,
                     ),
                     SwitchListTile(
                       contentPadding: EdgeInsets.zero,
                       secondary: const Icon(Icons.favorite_outline),
                       title: const Text("Реакции"),
-                      subtitle: const Text("Уведомления о реакциях на сообщения"),
+                      subtitle: const Text(
+                        "Уведомления о реакциях на сообщения",
+                      ),
                       value: _reactionsEnabled,
-                      onChanged: _notificationsEnabled ? (value) async {
-                        await _settingsService.setReactionsEnabled(value);
-                        setState(() => _reactionsEnabled = value);
-                        if (mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Настройки обновлены'),
-                              backgroundColor: Colors.green,
-                            ),
-                          );
-                        }
-                      } : null,
+                      onChanged: _notificationsEnabled
+                          ? (value) async {
+                              await _settingsService.setReactionsEnabled(value);
+                              setState(() => _reactionsEnabled = value);
+                              if (mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Настройки обновлены'),
+                                    backgroundColor: Colors.green,
+                                  ),
+                                );
+                              }
+                            }
+                          : null,
                     ),
                   ],
                 ),
               ),
               const SizedBox(height: 16),
-              
+
               // Настройки вибрации
               _OutlinedSection(
                 child: Column(
@@ -211,12 +227,13 @@ class _NotificationSettingsScreenState
                         _getVibrationDescription(_vibrationMode),
                         style: TextStyle(color: colors.primary),
                       ),
-                      onTap: _notificationsEnabled ? () => _showVibrationDialog() : null,
+                      onTap: _notificationsEnabled
+                          ? () => _showVibrationDialog()
+                          : null,
                     ),
                   ],
                 ),
               ),
-
             ],
           );
   }
@@ -238,7 +255,7 @@ class _NotificationSettingsScreenState
       _channelsEnabled = await _settingsService.areChannelsEnabled();
       _reactionsEnabled = await _settingsService.areReactionsEnabled();
       _vibrationMode = await _settingsService.getVibrationMode();
-      
+
       setState(() {});
     } catch (e) {
       print('Ошибка загрузки настроек: $e');
@@ -389,14 +406,18 @@ class _NotificationSettingsScreenState
                   ),
                 ),
                 const SizedBox(height: 16),
-                
+
                 // Настройки по типу чата
                 _OutlinedSection(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(left: 8, top: 8, bottom: 4),
+                        padding: const EdgeInsets.only(
+                          left: 8,
+                          top: 8,
+                          bottom: 4,
+                        ),
                         child: Text(
                           'Уведомления из чатов',
                           style: TextStyle(
@@ -411,79 +432,95 @@ class _NotificationSettingsScreenState
                         secondary: const Icon(Icons.person_outline),
                         title: const Text("Личные чаты"),
                         value: _privateChatsEnabled,
-                        onChanged: _notificationsEnabled ? (value) async {
-                          await _settingsService.setPrivateChatsEnabled(value);
-                          setState(() => _privateChatsEnabled = value);
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Настройки обновлены'),
-                                backgroundColor: Colors.green,
-                              ),
-                            );
-                          }
-                        } : null,
+                        onChanged: _notificationsEnabled
+                            ? (value) async {
+                                await _settingsService.setPrivateChatsEnabled(
+                                  value,
+                                );
+                                setState(() => _privateChatsEnabled = value);
+                                if (mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Настройки обновлены'),
+                                      backgroundColor: Colors.green,
+                                    ),
+                                  );
+                                }
+                              }
+                            : null,
                       ),
                       SwitchListTile(
                         contentPadding: EdgeInsets.zero,
                         secondary: const Icon(Icons.group_outlined),
                         title: const Text("Группы"),
                         value: _groupsEnabled,
-                        onChanged: _notificationsEnabled ? (value) async {
-                          await _settingsService.setGroupsEnabled(value);
-                          setState(() => _groupsEnabled = value);
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Настройки обновлены'),
-                                backgroundColor: Colors.green,
-                              ),
-                            );
-                          }
-                        } : null,
+                        onChanged: _notificationsEnabled
+                            ? (value) async {
+                                await _settingsService.setGroupsEnabled(value);
+                                setState(() => _groupsEnabled = value);
+                                if (mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Настройки обновлены'),
+                                      backgroundColor: Colors.green,
+                                    ),
+                                  );
+                                }
+                              }
+                            : null,
                       ),
                       SwitchListTile(
                         contentPadding: EdgeInsets.zero,
                         secondary: const Icon(Icons.campaign_outlined),
                         title: const Text("Каналы"),
                         value: _channelsEnabled,
-                        onChanged: _notificationsEnabled ? (value) async {
-                          await _settingsService.setChannelsEnabled(value);
-                          setState(() => _channelsEnabled = value);
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Настройки обновлены'),
-                                backgroundColor: Colors.green,
-                              ),
-                            );
-                          }
-                        } : null,
+                        onChanged: _notificationsEnabled
+                            ? (value) async {
+                                await _settingsService.setChannelsEnabled(
+                                  value,
+                                );
+                                setState(() => _channelsEnabled = value);
+                                if (mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Настройки обновлены'),
+                                      backgroundColor: Colors.green,
+                                    ),
+                                  );
+                                }
+                              }
+                            : null,
                       ),
                       SwitchListTile(
                         contentPadding: EdgeInsets.zero,
                         secondary: const Icon(Icons.favorite_outline),
                         title: const Text("Реакции"),
-                        subtitle: const Text("Уведомления о реакциях на сообщения"),
+                        subtitle: const Text(
+                          "Уведомления о реакциях на сообщения",
+                        ),
                         value: _reactionsEnabled,
-                        onChanged: _notificationsEnabled ? (value) async {
-                          await _settingsService.setReactionsEnabled(value);
-                          setState(() => _reactionsEnabled = value);
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Настройки обновлены'),
-                                backgroundColor: Colors.green,
-                              ),
-                            );
-                          }
-                        } : null,
+                        onChanged: _notificationsEnabled
+                            ? (value) async {
+                                await _settingsService.setReactionsEnabled(
+                                  value,
+                                );
+                                setState(() => _reactionsEnabled = value);
+                                if (mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Настройки обновлены'),
+                                      backgroundColor: Colors.green,
+                                    ),
+                                  );
+                                }
+                              }
+                            : null,
                       ),
                     ],
                   ),
                 ),
                 const SizedBox(height: 16),
-                
+
                 // Настройки вибрации
                 _OutlinedSection(
                   child: Column(
@@ -496,12 +533,13 @@ class _NotificationSettingsScreenState
                           _getVibrationDescription(_vibrationMode),
                           style: TextStyle(color: colors.primary),
                         ),
-                        onTap: _notificationsEnabled ? () => _showVibrationDialog() : null,
+                        onTap: _notificationsEnabled
+                            ? () => _showVibrationDialog()
+                            : null,
                       ),
                     ],
                   ),
                 ),
-
               ],
             ),
     );
@@ -518,7 +556,7 @@ class _OutlinedSection extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       decoration: BoxDecoration(
-        border: Border.all(color: colors.outline.withOpacity(0.3)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(12),
       ),
       child: child,

--- a/lib/screens/settings/notification_settings_screen.dart
+++ b/lib/screens/settings/notification_settings_screen.dart
@@ -271,23 +271,26 @@ class _NotificationSettingsScreenState
         return SimpleDialog(
           title: const Text('Вибрация'),
           children: [
-            RadioListTile<VibrationMode>(
-              title: const Text('Без вибрации'),
-              value: VibrationMode.none,
+            RadioGroup<VibrationMode>(
               groupValue: _vibrationMode,
               onChanged: (v) => Navigator.of(context).pop(v),
-            ),
-            RadioListTile<VibrationMode>(
-              title: const Text('Короткая'),
-              value: VibrationMode.short,
-              groupValue: _vibrationMode,
-              onChanged: (v) => Navigator.of(context).pop(v),
-            ),
-            RadioListTile<VibrationMode>(
-              title: const Text('Длинная'),
-              value: VibrationMode.long,
-              groupValue: _vibrationMode,
-              onChanged: (v) => Navigator.of(context).pop(v),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  RadioListTile<VibrationMode>(
+                    title: const Text('Без вибрации'),
+                    value: VibrationMode.none,
+                  ),
+                  RadioListTile<VibrationMode>(
+                    title: const Text('Короткая'),
+                    value: VibrationMode.short,
+                  ),
+                  RadioListTile<VibrationMode>(
+                    title: const Text('Длинная'),
+                    value: VibrationMode.long,
+                  ),
+                ],
+              ),
             ),
           ],
         );

--- a/lib/screens/settings/optimization_screen.dart
+++ b/lib/screens/settings/optimization_screen.dart
@@ -162,7 +162,7 @@ class _OutlinedSection extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        border: Border.all(color: colors.outline.withOpacity(0.3)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(12),
       ),
       child: child,

--- a/lib/screens/settings/plugins_screen.dart
+++ b/lib/screens/settings/plugins_screen.dart
@@ -58,20 +58,20 @@ class _PluginsScreenState extends State<PluginsScreen> {
           Icon(
             Icons.extension_off,
             size: 64,
-            color: theme.colorScheme.onSurface.withOpacity(0.3),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
           ),
           const SizedBox(height: 16),
           Text(
             'Нет установленных плагинов',
             style: theme.textTheme.titleMedium?.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.5),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
             ),
           ),
           const SizedBox(height: 8),
           Text(
             'Нажмите плюсик чтобы добавить плагин',
             style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.4),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
             ),
           ),
           const SizedBox(height: 24),
@@ -173,13 +173,15 @@ class _PluginsScreenState extends State<PluginsScreen> {
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
               ),
             Text(
               'Версия: ${plugin.version}',
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.6),
               ),
             ),
             if (summary.isNotEmpty) ...[
@@ -358,7 +360,9 @@ class _PluginCard extends StatelessWidget {
                         Text(
                           'v${plugin.version}${plugin.author != null ? ' • ${plugin.author}' : ''}',
                           style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurface.withOpacity(0.6),
+                            color: theme.colorScheme.onSurface.withValues(
+                              alpha: 0.6,
+                            ),
                           ),
                         ),
                       ],
@@ -372,7 +376,7 @@ class _PluginCard extends StatelessWidget {
                 Text(
                   plugin.description!,
                   style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurface.withOpacity(0.7),
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                   ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
@@ -423,13 +427,13 @@ class _PluginCard extends StatelessWidget {
           Icon(
             icon,
             size: 14,
-            color: theme.colorScheme.onSurface.withOpacity(0.6),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
           ),
           const SizedBox(width: 4),
           Text(
             text,
             style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.6),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
             ),
           ),
         ],
@@ -467,7 +471,7 @@ class _PluginDetailsSheet extends StatelessWidget {
               height: 4,
               margin: const EdgeInsets.only(bottom: 24),
               decoration: BoxDecoration(
-                color: theme.colorScheme.onSurface.withOpacity(0.2),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -501,7 +505,9 @@ class _PluginDetailsSheet extends StatelessWidget {
                     Text(
                       'Версия ${plugin.version}',
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withOpacity(0.6),
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.6,
+                        ),
                       ),
                     ),
                   ],
@@ -531,7 +537,7 @@ class _PluginDetailsSheet extends StatelessWidget {
             Text(
               'Плагин хуетень ниче не делает ',
               style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.5),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
               ),
             )
           else
@@ -573,7 +579,9 @@ class _PluginDetailsSheet extends StatelessWidget {
                         e.key,
                         style: theme.textTheme.bodySmall?.copyWith(
                           fontFamily: 'monospace',
-                          color: theme.colorScheme.onSurface.withOpacity(0.7),
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.7,
+                          ),
                         ),
                       ),
                     ),
@@ -605,13 +613,13 @@ class _PluginDetailsSheet extends StatelessWidget {
         Icon(
           icon,
           size: 20,
-          color: theme.colorScheme.onSurface.withOpacity(0.5),
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
         ),
         const SizedBox(width: 8),
         Text(
           '$label: ',
           style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onSurface.withOpacity(0.5),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
           ),
         ),
         Text(value, style: theme.textTheme.bodyMedium),

--- a/lib/screens/settings/privacy_security_screen.dart
+++ b/lib/screens/settings/privacy_security_screen.dart
@@ -269,9 +269,9 @@ class _PrivacySecurityScreenState extends State<PrivacySecurityScreen>
         Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: colors.surfaceContainerHighest.withOpacity(0.5),
+            color: colors.surfaceContainerHighest.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: colors.outline.withOpacity(0.2)),
+            border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
           ),
           child: Row(
             children: [
@@ -325,7 +325,7 @@ class _PrivacySecurityCard extends StatelessWidget {
             gradient: gradient,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -338,7 +338,7 @@ class _PrivacySecurityCard extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: colors.primaryContainer.withOpacity(0.5),
+                      color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Icon(icon, color: colors.primary, size: 24),

--- a/lib/screens/settings/privacy_settings_screen.dart
+++ b/lib/screens/settings/privacy_settings_screen.dart
@@ -155,39 +155,30 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
         return SimpleDialog(
           title: Text(title),
           children: [
-            _buildDialogOption(
-              'Все пользователи',
-              'ALL',
-              currentValue,
-              onSelect,
-            ),
-            _buildDialogOption(
-              'Только контакты',
-              'CONTACTS',
-              currentValue,
-              onSelect,
+            RadioGroup<String>(
+              groupValue: currentValue,
+              onChanged: (newValue) {
+                if (newValue != null) {
+                  onSelect(newValue);
+                  Navigator.of(context).pop();
+                }
+              },
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  RadioListTile<String>(
+                    value: 'ALL',
+                    title: Text('Все пользователи'),
+                  ),
+                  RadioListTile<String>(
+                    value: 'CONTACTS',
+                    title: Text('Только контакты'),
+                  ),
+                ],
+              ),
             ),
           ],
         );
-      },
-    );
-  }
-
-  Widget _buildDialogOption(
-    String title,
-    String value,
-    String groupValue,
-    Function(String) onSelect,
-  ) {
-    return RadioListTile<String>(
-      title: Text(title),
-      value: value,
-      groupValue: groupValue,
-      onChanged: (newValue) {
-        if (newValue != null) {
-          onSelect(newValue);
-          Navigator.of(context).pop();
-        }
       },
     );
   }

--- a/lib/screens/settings/privacy_settings_screen.dart
+++ b/lib/screens/settings/privacy_settings_screen.dart
@@ -404,7 +404,7 @@ class _OutlinedSection extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        border: Border.all(color: colors.outline.withOpacity(0.3)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(12),
       ),
       child: child,

--- a/lib/screens/settings/qr_authorize_screen.dart
+++ b/lib/screens/settings/qr_authorize_screen.dart
@@ -15,7 +15,7 @@ class QrAuthorizeScreen extends StatefulWidget {
 }
 
 class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
-  with TickerProviderStateMixin {
+    with TickerProviderStateMixin {
   final MobileScannerController _scannerController = MobileScannerController(
     detectionSpeed: DetectionSpeed.normal,
     facing: CameraFacing.back,
@@ -67,7 +67,8 @@ class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
     const double timeConstant = 0.12; // seconds; smaller = snappier
     final t = 1 - exp(-dtSeconds / timeConstant);
 
-    final nextAlignment = Alignment.lerp(_frameAlignment, _targetFrameAlignment, t) ??
+    final nextAlignment =
+        Alignment.lerp(_frameAlignment, _targetFrameAlignment, t) ??
         _targetFrameAlignment;
     final nextSide =
         lerpDouble(_frameSide, _targetFrameSide, t) ?? _targetFrameSide;
@@ -147,10 +148,9 @@ class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
                   Expanded(
                     child: Text(
                       'Вы хотите авторизоваться?',
-                      style: Theme.of(context)
-                          .textTheme
-                          .titleMedium
-                          ?.copyWith(fontWeight: FontWeight.w700),
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                   ),
                 ],
@@ -158,10 +158,9 @@ class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
               const SizedBox(height: 12),
               Text(
                 'Подтвердите действие, если доверяете устройству, которое сгенерировало этот QR-код.',
-                style: Theme.of(context)
-                    .textTheme
-                    .bodyMedium
-                    ?.copyWith(color: colors.onSurfaceVariant),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colors.onSurfaceVariant,
+                ),
               ),
               const SizedBox(height: 20),
               Row(
@@ -202,7 +201,11 @@ class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
       final cy = (center.dy / imageSize.height) * 2 - 1;
 
       final targetSide =
-          (bounds.width / imageSize.width) * (_screenWidth == 0 ? MediaQuery.of(context).size.width : _screenWidth) * 1.1;
+          (bounds.width / imageSize.width) *
+          (_screenWidth == 0
+              ? MediaQuery.of(context).size.width
+              : _screenWidth) *
+          1.1;
 
       _targetFrameAlignment = Alignment(
         cx.clamp(-1.0, 1.0),
@@ -215,7 +218,8 @@ class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
 
   Rect? _extractBounds(Barcode barcode) {
     final dynamic b = barcode;
-    final List<dynamic>? corners = (b.corners ?? b.cornerPoints) as List<dynamic>?;
+    final List<dynamic>? corners =
+        (b.corners ?? b.cornerPoints) as List<dynamic>?;
     if (corners == null || corners.isEmpty) return null;
 
     double minX = double.infinity;
@@ -353,15 +357,18 @@ class _QrAuthorizeScreenState extends State<QrAuthorizeScreen>
                   'Наведите камеру на QR-код, чтобы подтвердить авторизацию.',
                   textAlign: TextAlign.center,
                   style: TextStyle(
-                    color: Colors.white.withOpacity(0.9),
+                    color: Colors.white.withValues(alpha: 0.9),
                     fontWeight: FontWeight.w600,
                   ),
                 ),
                 const SizedBox(height: 12),
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 10,
+                  ),
                   decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.12),
+                    color: Colors.white.withValues(alpha: 0.12),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -403,15 +410,13 @@ class _ScannerOverlay extends StatelessWidget {
         const double borderRadius = 18;
         final double maxSide =
             constraints.hasBoundedWidth && constraints.hasBoundedHeight
-                ? (constraints.biggest.shortestSide * 0.9)
-                : frameSide;
+            ? (constraints.biggest.shortestSide * 0.9)
+            : frameSide;
         final double frameSize = frameSide.clamp(160.0, maxSide);
 
         return Stack(
           children: [
-            Container(
-              color: Colors.black.withOpacity(0.35),
-            ),
+            Container(color: Colors.black.withValues(alpha: 0.35)),
             AnimatedAlign(
               alignment: frameAlignment,
               duration: const Duration(milliseconds: 120),
@@ -424,9 +429,7 @@ class _ScannerOverlay extends StatelessWidget {
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(borderRadius),
                 ),
-                child: CustomPaint(
-                  painter: _CornerPainter(colors.primary),
-                ),
+                child: CustomPaint(painter: _CornerPainter(colors.primary)),
               ),
             ),
           ],

--- a/lib/screens/settings/qr_login_screen.dart
+++ b/lib/screens/settings/qr_login_screen.dart
@@ -173,7 +173,7 @@ class _QrLoginScreenState extends State<QrLoginScreen> {
             Icon(
               Icons.qr_code_scanner_rounded,
               size: 150,
-              color: colors.onSurface.withOpacity(0.3),
+              color: colors.onSurface.withValues(alpha: 0.3),
             ),
             const SizedBox(height: 16),
             Text(
@@ -201,7 +201,7 @@ class _QrLoginScreenState extends State<QrLoginScreen> {
               borderRadius: BorderRadius.circular(24.0),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.1),
+                  color: Colors.black.withValues(alpha: 0.1),
                   spreadRadius: 2,
                   blurRadius: 15,
                   offset: const Offset(0, 4),
@@ -261,7 +261,7 @@ class _QrLoginScreenState extends State<QrLoginScreen> {
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: colors.errorContainer.withOpacity(0.3),
+                color: colors.errorContainer.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: const Row(

--- a/lib/screens/settings/reconnection_screen.dart
+++ b/lib/screens/settings/reconnection_screen.dart
@@ -170,8 +170,8 @@ class _ReconnectionScreenState extends State<ReconnectionScreen> {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
 
-    return WillPopScope(
-      onWillPop: () async => false,
+    return PopScope(
+      canPop: false,
       child: Scaffold(
         backgroundColor: colors.surface,
         body: Container(

--- a/lib/screens/settings/reconnection_screen.dart
+++ b/lib/screens/settings/reconnection_screen.dart
@@ -177,7 +177,7 @@ class _ReconnectionScreenState extends State<ReconnectionScreen> {
         body: Container(
           width: double.infinity,
           height: double.infinity,
-          color: colors.surface.withOpacity(0.95),
+          color: colors.surface.withValues(alpha: 0.95),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
@@ -255,7 +255,9 @@ class _ReconnectionScreenState extends State<ReconnectionScreen> {
                 decoration: BoxDecoration(
                   color: colors.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: colors.outline.withOpacity(0.3)),
+                  border: Border.all(
+                    color: colors.outline.withValues(alpha: 0.3),
+                  ),
                 ),
                 child: Row(
                   children: [

--- a/lib/screens/settings/security_settings_screen.dart
+++ b/lib/screens/settings/security_settings_screen.dart
@@ -341,10 +341,12 @@ class _SecuritySettingsScreenState extends State<SecuritySettingsScreen>
           decoration: BoxDecoration(
             color: Theme.of(
               context,
-            ).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
-              color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+              color: Theme.of(
+                context,
+              ).colorScheme.outline.withValues(alpha: 0.2),
             ),
           ),
           child: Row(
@@ -403,7 +405,7 @@ class _SecurityCard extends StatelessWidget {
             gradient: gradient,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -416,7 +418,7 @@ class _SecurityCard extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: colors.primaryContainer.withOpacity(0.5),
+                      color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Icon(icon, color: colors.primary, size: 24),

--- a/lib/screens/settings/session_spoofing_screen.dart
+++ b/lib/screens/settings/session_spoofing_screen.dart
@@ -86,7 +86,7 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
 
     _appVersionController.text = '25.21.3';
     _localeController.text = Platform.localeName.split('_').first;
-    
+
     // Generate screen in Android format: "xxhdpi 420dpi 1080x2400"
     final dpi = (160 * pixelRatio).round();
     String densityBucket;
@@ -120,8 +120,8 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
           '${androidInfo.manufacturer} ${androidInfo.model}';
       _osVersionController.text = 'Android ${androidInfo.version.release}';
       _selectedDeviceType = 'ANDROID';
-      _selectedArch = androidInfo.supportedAbis.isNotEmpty 
-          ? androidInfo.supportedAbis.first 
+      _selectedArch = androidInfo.supportedAbis.isNotEmpty
+          ? androidInfo.supportedAbis.first
           : 'arm64-v8a';
       _buildNumberController.text = '6498';
     } else if (Platform.isIOS) {
@@ -143,14 +143,18 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
 
   Future<void> _applyGeneratedData() async {
     final filteredPresets = devicePresets
-        .where((p) => p.deviceType != 'WEB' && p.deviceType == _selectedDeviceType)
+        .where(
+          (p) => p.deviceType != 'WEB' && p.deviceType == _selectedDeviceType,
+        )
         .toList();
 
     if (filteredPresets.isEmpty) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Нет доступных пресетов для типа устройства $_selectedDeviceType.'),
+            content: Text(
+              'Нет доступных пресетов для типа устройства $_selectedDeviceType.',
+            ),
           ),
         );
       }
@@ -170,7 +174,7 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
       _deviceIdController.text = _generateDeviceId();
 
       _selectedDeviceType = preset.deviceType;
-      
+
       // Set arch based on device type
       if (preset.deviceType == 'ANDROID') {
         _selectedArch = 'arm64-v8a';
@@ -321,7 +325,10 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
     await prefs.setString('spoof_devicetype', _selectedDeviceType);
     await prefs.setString('spoof_appversion', _appVersionController.text);
     await prefs.setString('spoof_arch', _selectedArch);
-    await prefs.setInt('spoof_buildnumber', int.tryParse(_buildNumberController.text) ?? 6498);
+    await prefs.setInt(
+      'spoof_buildnumber',
+      int.tryParse(_buildNumberController.text) ?? 6498,
+    );
   }
 
   Future<void> _handleVersionCheck() async {
@@ -419,7 +426,9 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
 
   Widget _buildInfoCard() {
     return Card(
-      color: Theme.of(context).colorScheme.secondaryContainer.withOpacity(0.5),
+      color: Theme.of(
+        context,
+      ).colorScheme.secondaryContainer.withValues(alpha: 0.5),
       elevation: 0,
       child: Padding(
         padding: const EdgeInsets.all(12.0),
@@ -518,10 +527,7 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              "Тип устройства",
-              style: theme.textTheme.titleMedium,
-            ),
+            Text("Тип устройства", style: theme.textTheme.titleMedium),
             const SizedBox(height: 12),
             _buildDescriptionTile(
               icon: Icons.info_outline,
@@ -661,12 +667,12 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
               controller: _deviceIdController,
               decoration: _inputDecoration('ID Устройства', Icons.tag_outlined)
                   .copyWith(
-                suffixIcon: IconButton(
-                  icon: const Icon(Icons.autorenew_outlined),
-                  tooltip: 'Сгенерировать новый ID',
-                  onPressed: _generateNewDeviceId,
-                ),
-              ),
+                    suffixIcon: IconButton(
+                      icon: const Icon(Icons.autorenew_outlined),
+                      tooltip: 'Сгенерировать новый ID',
+                      onPressed: _generateNewDeviceId,
+                    ),
+                  ),
             ),
             const SizedBox(height: 16),
             TextField(
@@ -729,11 +735,26 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
                 Icons.memory_outlined,
               ),
               items: const [
-                DropdownMenuItem(value: 'arm64-v8a', child: Text('arm64-v8a (64-bit ARM)')),
-                DropdownMenuItem(value: 'armeabi-v7a', child: Text('armeabi-v7a (32-bit ARM)')),
-                DropdownMenuItem(value: 'x86', child: Text('x86 (32-bit Intel)')),
-                DropdownMenuItem(value: 'x86_64', child: Text('x86_64 (64-bit Intel)')),
-                DropdownMenuItem(value: 'arm64', child: Text('arm64 (iOS/Desktop)')),
+                DropdownMenuItem(
+                  value: 'arm64-v8a',
+                  child: Text('arm64-v8a (64-bit ARM)'),
+                ),
+                DropdownMenuItem(
+                  value: 'armeabi-v7a',
+                  child: Text('armeabi-v7a (32-bit ARM)'),
+                ),
+                DropdownMenuItem(
+                  value: 'x86',
+                  child: Text('x86 (32-bit Intel)'),
+                ),
+                DropdownMenuItem(
+                  value: 'x86_64',
+                  child: Text('x86_64 (64-bit Intel)'),
+                ),
+                DropdownMenuItem(
+                  value: 'arm64',
+                  child: Text('arm64 (iOS/Desktop)'),
+                ),
               ],
               onChanged: (value) {
                 if (value != null) {

--- a/lib/screens/settings/session_spoofing_screen.dart
+++ b/lib/screens/settings/session_spoofing_screen.dart
@@ -537,7 +537,7 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
             ),
             const SizedBox(height: 12),
             DropdownButtonFormField<String>(
-              value: _selectedDeviceType,
+              initialValue: _selectedDeviceType,
               decoration: _inputDecoration(
                 'Тип устройства',
                 Icons.devices_other_outlined,
@@ -729,7 +729,7 @@ class _SessionSpoofingScreenState extends State<SessionSpoofingScreen> {
             ),
             const SizedBox(height: 16),
             DropdownButtonFormField<String>(
-              value: _selectedArch,
+              initialValue: _selectedArch,
               decoration: _inputDecoration(
                 'Архитектура',
                 Icons.memory_outlined,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -712,8 +712,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                 boxShadow: expansionProgress > 0
                     ? [
                         BoxShadow(
-                          color: colors.shadow.withOpacity(
-                            0.2 * expansionProgress,
+                          color: colors.shadow.withValues(
+                            alpha: 0.2 * expansionProgress,
                           ),
                           blurRadius: 20 * expansionProgress,
                           offset: Offset(0, 8 * expansionProgress),
@@ -767,7 +767,7 @@ class _SettingsScreenState extends State<SettingsScreen>
               'ID: ${_myProfile!.id}',
               style: GoogleFonts.manrope(
                 textStyle: textTheme.bodyMedium,
-                color: colors.onSurfaceVariant.withOpacity(0.7),
+                color: colors.onSurfaceVariant.withValues(alpha: 0.7),
               ),
               textAlign: TextAlign.center,
             ),
@@ -799,12 +799,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                   ),
                   borderRadius: BorderRadius.circular(20),
                   border: Border.all(
-                    color: colors.primary.withOpacity(0.3),
+                    color: colors.primary.withValues(alpha: 0.3),
                     width: 2,
                   ),
                   boxShadow: [
                     BoxShadow(
-                      color: colors.primary.withOpacity(0.1),
+                      color: colors.primary.withValues(alpha: 0.1),
                       blurRadius: 20,
                       offset: const Offset(0, 4),
                     ),
@@ -898,7 +898,7 @@ class _SettingsScreenState extends State<SettingsScreen>
               ),
               borderRadius: BorderRadius.circular(20),
               border: Border.all(
-                color: colors.outline.withOpacity(0.2),
+                color: colors.outline.withValues(alpha: 0.2),
                 width: 1,
               ),
             ),
@@ -908,7 +908,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                 Container(
                   padding: const EdgeInsets.all(10),
                   decoration: BoxDecoration(
-                    color: colors.primaryContainer.withOpacity(0.5),
+                    color: colors.primaryContainer.withValues(alpha: 0.5),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Icon(icon, color: colors.primary, size: 24),

--- a/lib/screens/settings/socket_log_screen.dart
+++ b/lib/screens/settings/socket_log_screen.dart
@@ -490,7 +490,9 @@ class _SocketLogScreenState extends State<SocketLogScreen>
               "[${DateFormat('HH:mm:ss.SSS').format(entry.timestamp)}] ${entry.message}",
         )
         .join('\n\n');
-    await Share.share(logText, subject: 'Gwid Connection Log');
+    await SharePlus.instance.share(
+      ShareParams(text: logText, subject: 'Gwid Connection Log'),
+    );
   }
 
   Future<void> _exportLogsToFile() async {
@@ -516,7 +518,9 @@ class _SocketLogScreenState extends State<SocketLogScreen>
             content: Text('Логи сохранены: ${file.path}'),
             action: SnackBarAction(
               label: 'Открыть',
-              onPressed: () => Share.shareXFiles([XFile(file.path)]),
+              onPressed: () => SharePlus.instance.share(
+                ShareParams(files: [XFile(file.path)]),
+              ),
             ),
           ),
         );

--- a/lib/screens/settings/socket_log_screen.dart
+++ b/lib/screens/settings/socket_log_screen.dart
@@ -372,7 +372,7 @@ class _SocketLogScreenState extends State<SocketLogScreen>
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: Colors.blue.withOpacity(0.2),
+                  color: Colors.blue.withValues(alpha: 0.2),
                   border: Border(
                     bottom: BorderSide(color: Colors.blue, width: 2),
                   ),
@@ -423,7 +423,7 @@ class _SocketLogScreenState extends State<SocketLogScreen>
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: Colors.green.withOpacity(0.2),
+                  color: Colors.green.withValues(alpha: 0.2),
                   border: Border(
                     bottom: BorderSide(color: Colors.green, width: 2),
                   ),
@@ -840,7 +840,7 @@ class _SocketLogScreenState extends State<SocketLogScreen>
           if (_isPaused)
             Container(
               width: double.infinity,
-              color: Colors.orange.withOpacity(0.2),
+              color: Colors.orange.withValues(alpha: 0.2),
               padding: const EdgeInsets.symmetric(vertical: 8),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -861,7 +861,7 @@ class _SocketLogScreenState extends State<SocketLogScreen>
               _userScrolledUp &&
               _viewMode != ViewMode.split)
             Material(
-              color: Colors.blue.withOpacity(0.2),
+              color: Colors.blue.withValues(alpha: 0.2),
               child: InkWell(
                 onTap: _toggleAutoScroll,
                 child: Container(
@@ -992,39 +992,39 @@ class _AnimatedLogEntryCardState extends State<AnimatedLogEntryCard>
         return (
           Icons.arrow_upward_rounded,
           theme.colorScheme.primary,
-          theme.colorScheme.primary.withOpacity(0.1),
+          theme.colorScheme.primary.withValues(alpha: 0.1),
         );
       case LogType.receive:
         return (
           Icons.arrow_downward_rounded,
           Colors.green,
-          Colors.green.withOpacity(0.1),
+          Colors.green.withValues(alpha: 0.1),
         );
       case LogType.pingpong:
         return (
           Icons.sync_alt_rounded,
           Colors.grey,
-          Colors.grey.withOpacity(0.1),
+          Colors.grey.withValues(alpha: 0.1),
         );
       case LogType.status:
         if (message.startsWith('✅')) {
           return (
             Icons.check_circle_rounded,
             Colors.green,
-            Colors.green.withOpacity(0.1),
+            Colors.green.withValues(alpha: 0.1),
           );
         }
         if (message.startsWith('❌')) {
           return (
             Icons.error_rounded,
             theme.colorScheme.error,
-            theme.colorScheme.error.withOpacity(0.1),
+            theme.colorScheme.error.withValues(alpha: 0.1),
           );
         }
         return (
           Icons.info_rounded,
           Colors.orange.shade600,
-          Colors.orange.withOpacity(0.1),
+          Colors.orange.withValues(alpha: 0.1),
         );
     }
   }
@@ -1163,7 +1163,7 @@ class _AnimatedLogEntryCardState extends State<AnimatedLogEntryCard>
                       Container(
                         padding: const EdgeInsets.all(8),
                         decoration: BoxDecoration(
-                          color: color.withOpacity(0.2),
+                          color: color.withValues(alpha: 0.2),
                           borderRadius: BorderRadius.circular(8),
                         ),
                         child: Icon(icon, color: color, size: 20),
@@ -1193,7 +1193,7 @@ class _AnimatedLogEntryCardState extends State<AnimatedLogEntryCard>
                                         vertical: 2,
                                       ),
                                       decoration: BoxDecoration(
-                                        color: color.withOpacity(0.2),
+                                        color: color.withValues(alpha: 0.2),
                                         borderRadius: BorderRadius.circular(12),
                                       ),
                                       child: Text(
@@ -1212,7 +1212,7 @@ class _AnimatedLogEntryCardState extends State<AnimatedLogEntryCard>
                                         vertical: 2,
                                       ),
                                       decoration: BoxDecoration(
-                                        color: color.withOpacity(0.2),
+                                        color: color.withValues(alpha: 0.2),
                                         borderRadius: BorderRadius.circular(12),
                                       ),
                                       child: Text(

--- a/lib/screens/settings/special_settings_screen.dart
+++ b/lib/screens/settings/special_settings_screen.dart
@@ -264,10 +264,7 @@ class _SpecialSettingsScreenState extends State<SpecialSettingsScreen>
             gradient: LinearGradient(
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
-              colors: [
-                colors.surfaceContainerHighest,
-                colors.surfaceContainer,
-              ],
+              colors: [colors.surfaceContainerHighest, colors.surfaceContainer],
             ),
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
@@ -285,7 +282,11 @@ class _SpecialSettingsScreenState extends State<SpecialSettingsScreen>
                       color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: Icon(Icons.access_time, color: colors.primary, size: 24),
+                    child: Icon(
+                      Icons.access_time,
+                      color: colors.primary,
+                      size: 24,
+                    ),
                   ),
                   const SizedBox(width: 16),
                   Expanded(
@@ -333,7 +334,11 @@ class _SpecialSettingsScreenState extends State<SpecialSettingsScreen>
                       color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: Icon(Icons.delete_outline, color: colors.primary, size: 24),
+                    child: Icon(
+                      Icons.delete_outline,
+                      color: colors.primary,
+                      size: 24,
+                    ),
                   ),
                   const SizedBox(width: 16),
                   Expanded(
@@ -381,7 +386,11 @@ class _SpecialSettingsScreenState extends State<SpecialSettingsScreen>
                       color: colors.primaryContainer.withValues(alpha: 0.5),
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: Icon(Icons.edit_outlined, color: colors.primary, size: 24),
+                    child: Icon(
+                      Icons.edit_outlined,
+                      color: colors.primary,
+                      size: 24,
+                    ),
                   ),
                   const SizedBox(width: 16),
                   Expanded(

--- a/lib/screens/settings/storage_screen.dart
+++ b/lib/screens/settings/storage_screen.dart
@@ -269,13 +269,13 @@ class _StorageScreenState extends State<StorageScreen>
                   Icon(
                     Icons.storage_outlined,
                     size: 64,
-                    color: colors.onSurface.withOpacity(0.3),
+                    color: colors.onSurface.withValues(alpha: 0.3),
                   ),
                   const SizedBox(height: 16),
                   Text(
                     'Не удалось загрузить информацию о хранилище',
                     style: TextStyle(
-                      color: colors.onSurface.withOpacity(0.6),
+                      color: colors.onSurface.withValues(alpha: 0.6),
                       fontSize: 16,
                     ),
                   ),
@@ -321,7 +321,7 @@ class _StorageScreenState extends State<StorageScreen>
             child: Container(
               width: double.infinity,
               height: double.infinity,
-              color: Colors.black.withOpacity(0.3),
+              color: Colors.black.withValues(alpha: 0.3),
             ),
           ),
 
@@ -335,7 +335,7 @@ class _StorageScreenState extends State<StorageScreen>
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.3),
+                    color: Colors.black.withValues(alpha: 0.3),
                     blurRadius: 20,
                     offset: const Offset(0, 10),
                   ),
@@ -421,7 +421,7 @@ class _StorageScreenState extends State<StorageScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Column(
         children: [
@@ -478,7 +478,7 @@ class _StorageScreenState extends State<StorageScreen>
                             'из ${_formatBytes(totalSize)}',
                             style: TextStyle(
                               fontSize: 12,
-                              color: colors.onSurface.withOpacity(0.7),
+                              color: colors.onSurface.withValues(alpha: 0.7),
                             ),
                           ),
                         ],
@@ -547,7 +547,7 @@ class _StorageScreenState extends State<StorageScreen>
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: colors.outline.withOpacity(0.2)),
+        border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -615,7 +615,7 @@ class _StorageScreenState extends State<StorageScreen>
             width: 40,
             height: 40,
             decoration: BoxDecoration(
-              color: color.withOpacity(0.1),
+              color: color.withValues(alpha: 0.1),
               borderRadius: BorderRadius.zero,
             ),
             child: Icon(icon, color: color, size: 20),
@@ -638,7 +638,7 @@ class _StorageScreenState extends State<StorageScreen>
                   size,
                   style: TextStyle(
                     fontSize: 12,
-                    color: colors.onSurface.withOpacity(0.6),
+                    color: colors.onSurface.withValues(alpha: 0.6),
                   ),
                 ),
               ],
@@ -748,7 +748,7 @@ class _StorageScreenState extends State<StorageScreen>
           decoration: BoxDecoration(
             color: colors.surface,
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: colors.outline.withOpacity(0.2)),
+            border: Border.all(color: colors.outline.withValues(alpha: 0.2)),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -773,7 +773,7 @@ class _StorageScreenState extends State<StorageScreen>
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: colors.surfaceContainerHighest.withOpacity(0.5),
+                  color: colors.surfaceContainerHighest.withValues(alpha: 0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(
@@ -786,7 +786,7 @@ class _StorageScreenState extends State<StorageScreen>
                             'Текущая папка:',
                             style: TextStyle(
                               fontSize: 12,
-                              color: colors.onSurface.withOpacity(0.6),
+                              color: colors.onSurface.withValues(alpha: 0.6),
                             ),
                           ),
                           const SizedBox(height: 4),

--- a/lib/screens/token_auth_screen.dart
+++ b/lib/screens/token_auth_screen.dart
@@ -494,7 +494,7 @@ class _TokenAuthScreenState extends State<TokenAuthScreen>
               ),
               if (_isLoading)
                 Container(
-                  color: Colors.black.withOpacity(0.5),
+                  color: Colors.black.withValues(alpha: 0.5),
                   child: const Center(child: CircularProgressIndicator()),
                 ),
             ],
@@ -539,7 +539,7 @@ class _AuthMethodCard extends StatelessWidget {
             gradient: gradient,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -581,7 +581,7 @@ class _AuthMethodCard extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: colors.secondaryContainer.withOpacity(0.5),
+                    color: colors.secondaryContainer.withValues(alpha: 0.5),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -660,7 +660,7 @@ class _TokenAuthCard extends StatelessWidget {
             ),
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colors.outline.withOpacity(0.2),
+              color: colors.outline.withValues(alpha: 0.2),
               width: 1,
             ),
           ),
@@ -705,7 +705,7 @@ class _TokenAuthCard extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: colors.secondaryContainer.withOpacity(0.5),
+                  color: colors.secondaryContainer.withValues(alpha: 0.5),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Row(

--- a/lib/services/chat_cache_service.dart
+++ b/lib/services/chat_cache_service.dart
@@ -192,7 +192,6 @@ class ChatCacheService {
           )
           .toList();
 
-
       await _cacheService.set(key, messagesData, ttl: _messagesTTL);
       print('Кэшировано ${messages.length} сообщений для чата $chatId');
     } catch (e) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -167,17 +167,12 @@ class NotificationService {
             : (chatIdDynamic is num ? chatIdDynamic.toInt() : null);
         final text = args['text'] as String?;
 
-        print(
-          "🔔 Получен ответ из уведомления: chatId=$chatId, text=$text",
-        );
+        print("🔔 Получен ответ из уведомления: chatId=$chatId, text=$text");
 
         if (chatId != null && text != null && text.isNotEmpty) {
           try {
             // Отправляем сообщение через API
-            ApiService.instance.sendMessage(
-              chatId,
-              text,
-            );
+            ApiService.instance.sendMessage(chatId, text);
             print("✅ Сообщение из уведомления отправлено успешно");
           } catch (e) {
             print("❌ Ошибка отправки сообщения из уведомления: $e");
@@ -730,10 +725,9 @@ class NotificationService {
         category: AndroidNotificationCategory.message,
         showWhen: true,
         enableVibration: enableVibration,
-        vibrationPattern:
-            enableVibration
-                ? typed_data.Int64List.fromList(vibrationPattern)
-                : null,
+        vibrationPattern: enableVibration
+            ? typed_data.Int64List.fromList(vibrationPattern)
+            : null,
         playSound: true,
         icon: 'notification_icon',
         styleInformation: BigTextStyleInformation(

--- a/lib/services/notification_settings_service.dart
+++ b/lib/services/notification_settings_service.dart
@@ -2,18 +2,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
 
 /// Типы чатов для настроек уведомлений
-enum ChatType {
-  private,
-  group,
-  channel,
-}
+enum ChatType { private, group, channel }
 
 /// Режим вибрации
-enum VibrationMode {
-  none,
-  short,
-  long,
-}
+enum VibrationMode { none, short, long }
 
 /// Сервис для управления настройками уведомлений
 class NotificationSettingsService {
@@ -29,7 +21,7 @@ class NotificationSettingsService {
   static const String _keyReactionsEnabled = 'notifications_reactions';
   static const String _keyVibrationMode = 'notifications_vibration_mode';
   static const String _keyChatExceptions = 'notifications_chat_exceptions';
-  
+
   // Константы по умолчанию
   static const VibrationMode _defaultVibrationMode = VibrationMode.short;
 
@@ -98,7 +90,7 @@ class NotificationSettingsService {
     final prefs = await SharedPreferences.getInstance();
     final modeString = prefs.getString(_keyVibrationMode);
     if (modeString == null) return _defaultVibrationMode;
-    
+
     switch (modeString) {
       case 'none':
         return VibrationMode.none;
@@ -128,7 +120,7 @@ class NotificationSettingsService {
 
     try {
       final decoded = json.decode(exceptionsJson) as Map<String, dynamic>;
-      
+
       // Преобразуем ключи из String в int
       final result = <int, Map<String, dynamic>>{};
       decoded.forEach((key, value) {
@@ -180,10 +172,7 @@ class NotificationSettingsService {
     // Если исключений нет, используем глобальные настройки
     final globalEnabled = await areNotificationsEnabled();
     if (!globalEnabled) {
-      return {
-        'enabled': false,
-        'vibration': VibrationMode.none.name,
-      };
+      return {'enabled': false, 'vibration': VibrationMode.none.name};
     }
 
     // Проверяем настройки для типа чата
@@ -198,10 +187,7 @@ class NotificationSettingsService {
 
     final vibrationMode = await getVibrationMode();
 
-    return {
-      'enabled': typeEnabled,
-      'vibration': vibrationMode.name,
-    };
+    return {'enabled': typeEnabled, 'vibration': vibrationMode.name};
   }
 
   /// Проверить, должны ли показываться уведомления для чата
@@ -223,13 +209,13 @@ class NotificationSettingsService {
     Map<int, Map<String, dynamic>> exceptions,
   ) async {
     final prefs = await SharedPreferences.getInstance();
-    
+
     // Преобразуем ключи int в String для JSON
     final Map<String, dynamic> toSave = {};
     exceptions.forEach((key, value) {
       toSave[key.toString()] = value;
     });
-    
+
     await prefs.setString(_keyChatExceptions, json.encode(toSave));
   }
 }

--- a/lib/services/version_checker.dart
+++ b/lib/services/version_checker.dart
@@ -3,7 +3,8 @@ import 'package:http/http.dart' as http;
 
 class VersionChecker {
   static const String _packageName = 'ru.oneme.app';
-  static const String _apiUrl = 'https://backapi.rustore.ru/applicationData/overallInfo/$_packageName';
+  static const String _apiUrl =
+      'https://backapi.rustore.ru/applicationData/overallInfo/$_packageName';
 
   static Future<String> getLatestVersion() async {
     final info = await getLatestVersionInfo();
@@ -38,10 +39,7 @@ class VersionChecker {
 
       print('[SUCCESS] Version: $versionName, Build: $versionCode');
 
-      return {
-        'versionName': versionName,
-        'versionCode': versionCode,
-      };
+      return {'versionName': versionName, 'versionCode': versionCode};
     } catch (e) {
       throw Exception('Не удалось получить информацию о версии: $e');
     }

--- a/lib/utils/device_presets.dart
+++ b/lib/utils/device_presets.dart
@@ -1,4 +1,3 @@
-
 class DevicePreset {
   final String deviceType;
   final String userAgent;
@@ -19,9 +18,7 @@ class DevicePreset {
   });
 }
 
-
 final List<DevicePreset> devicePresets = [
-
   DevicePreset(
     deviceType: 'ANDROID',
     userAgent:
@@ -403,8 +400,6 @@ final List<DevicePreset> devicePresets = [
     locale: 'zh-HK',
   ),
 
-
-
   DevicePreset(
     deviceType: 'IOS',
     userAgent:
@@ -646,7 +641,6 @@ final List<DevicePreset> devicePresets = [
     locale: 'cs-CZ',
   ),
 
-
   DevicePreset(
     deviceType: 'DESKTOP',
     userAgent:
@@ -697,8 +691,6 @@ final List<DevicePreset> devicePresets = [
     timezone: 'America/Los_Angeles',
     locale: 'en-US',
   ),
-
-
 
   DevicePreset(
     deviceType: 'WEB',
@@ -751,7 +743,6 @@ final List<DevicePreset> devicePresets = [
     locale: 'es-ES',
   ),
 
-
   DevicePreset(
     deviceType: 'WEB',
     userAgent:
@@ -783,7 +774,6 @@ final List<DevicePreset> devicePresets = [
     locale: 'pl-PL',
   ),
 
-
   DevicePreset(
     deviceType: 'WEB',
     userAgent:
@@ -804,7 +794,6 @@ final List<DevicePreset> devicePresets = [
     timezone: 'America/Sao_Paulo',
     locale: 'pt-BR',
   ),
-
 
   DevicePreset(
     deviceType: 'WEB',
@@ -847,7 +836,6 @@ final List<DevicePreset> devicePresets = [
     locale: 'en-GB',
   ),
 
-
   DevicePreset(
     deviceType: 'WEB',
     userAgent:
@@ -868,7 +856,6 @@ final List<DevicePreset> devicePresets = [
     timezone: 'Europe/Berlin',
     locale: 'de-DE',
   ),
-
 
   DevicePreset(
     deviceType: 'WEB',
@@ -900,7 +887,6 @@ final List<DevicePreset> devicePresets = [
     timezone: 'Asia/Tokyo',
     locale: 'ja-JP',
   ),
-
 
   DevicePreset(
     deviceType: 'WEB',
@@ -943,7 +929,6 @@ final List<DevicePreset> devicePresets = [
     locale: 'zh-CN',
   ),
 
-
   DevicePreset(
     deviceType: 'WEB',
     userAgent:
@@ -974,7 +959,6 @@ final List<DevicePreset> devicePresets = [
     timezone: 'Asia/Dubai',
     locale: 'ar-AE',
   ),
-
 
   DevicePreset(
     deviceType: 'WEB',

--- a/lib/utils/full_screen_video_player.dart
+++ b/lib/utils/full_screen_video_player.dart
@@ -277,7 +277,7 @@ class _FullScreenVideoPlayerState extends State<FullScreenVideoPlayer>
                     child: Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
-                        color: Colors.black.withOpacity(0.7),
+                        color: Colors.black.withValues(alpha: 0.7),
                         borderRadius: BorderRadius.circular(16),
                       ),
                       child: Column(
@@ -428,10 +428,10 @@ class _VideoControls extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            Colors.black.withOpacity(0.7),
+            Colors.black.withValues(alpha: 0.7),
             Colors.transparent,
             Colors.transparent,
-            Colors.black.withOpacity(0.7),
+            Colors.black.withValues(alpha: 0.7),
           ],
         ),
       ),
@@ -446,7 +446,7 @@ class _VideoControls extends StatelessWidget {
                     onPressed: onBack,
                     icon: const Icon(Icons.arrow_back),
                     style: IconButton.styleFrom(
-                      backgroundColor: Colors.black.withOpacity(0.5),
+                      backgroundColor: Colors.black.withValues(alpha: 0.5),
                       foregroundColor: Colors.white,
                       shape: const CircleBorder(),
                     ),
@@ -455,7 +455,7 @@ class _VideoControls extends StatelessWidget {
                   FilledButton.tonal(
                     onPressed: onSpeedTap,
                     style: FilledButton.styleFrom(
-                      backgroundColor: Colors.black.withOpacity(0.5),
+                      backgroundColor: Colors.black.withValues(alpha: 0.5),
                       foregroundColor: Colors.white,
                       padding: const EdgeInsets.symmetric(
                         horizontal: 16,
@@ -593,7 +593,7 @@ class _MaterialYouControlButton extends StatelessWidget {
       return FilledButton.tonal(
         onPressed: onTap,
         style: FilledButton.styleFrom(
-          backgroundColor: Colors.white.withOpacity(0.16),
+          backgroundColor: Colors.white.withValues(alpha: 0.16),
           foregroundColor: Colors.white,
           padding: const EdgeInsets.all(14),
           shape: const CircleBorder(),
@@ -711,7 +711,7 @@ class _CustomProgressBarState extends State<_CustomProgressBar> {
                   child: Container(
                     height: 4,
                     decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.3),
+                      color: Colors.white.withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
@@ -743,7 +743,7 @@ class _CustomProgressBarState extends State<_CustomProgressBar> {
                         width: bufferedWidthPx,
                         height: 4,
                         decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.5),
+                          color: Colors.white.withValues(alpha: 0.5),
                           borderRadius: BorderRadius.circular(2),
                         ),
                       ),
@@ -776,7 +776,7 @@ class _CustomProgressBarState extends State<_CustomProgressBar> {
                         shape: BoxShape.circle,
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.3),
+                            color: Colors.black.withValues(alpha: 0.3),
                             blurRadius: 4,
                             offset: const Offset(0, 2),
                           ),

--- a/lib/utils/spoofing_service.dart
+++ b/lib/utils/spoofing_service.dart
@@ -1,17 +1,14 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SpoofingService {
-
-
   static Future<Map<String, dynamic>?> getSpoofedSessionData() async {
     final prefs = await SharedPreferences.getInstance();
 
     final isEnabled = prefs.getBool('spoofing_enabled') ?? false;
 
     if (!isEnabled) {
-      return null; 
+      return null;
     }
-
 
     return {
       'device_name': prefs.getString('spoof_devicename'),

--- a/lib/utils/theme_provider.dart
+++ b/lib/utils/theme_provider.dart
@@ -1185,9 +1185,12 @@ class ThemeProvider with ChangeNotifier {
   Future<void> setUseGlassPanels(bool value) async {
     _activeTheme = _activeTheme.copyWith(useGlassPanels: value);
     _useGlassPanelsSaveTimer?.cancel();
-    _useGlassPanelsSaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _useGlassPanelsSaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setTopBarBlur(double value) async {
@@ -1263,9 +1266,12 @@ class ThemeProvider with ChangeNotifier {
   Future<void> setUseCustomChatWallpaper(bool value) async {
     _activeTheme = _activeTheme.copyWith(useCustomChatWallpaper: value);
     _useCustomChatWallpaperSaveTimer?.cancel();
-    _useCustomChatWallpaperSaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _useCustomChatWallpaperSaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setChatWallpaperType(ChatWallpaperType type) async {
@@ -1415,17 +1421,23 @@ class ThemeProvider with ChangeNotifier {
   Future<void> setShowDeletedMessages(bool value) async {
     _activeTheme = _activeTheme.copyWith(showDeletedMessages: value);
     _showDeletedMessagesSaveTimer?.cancel();
-    _showDeletedMessagesSaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _showDeletedMessagesSaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setViewRedactHistory(bool value) async {
     _activeTheme = _activeTheme.copyWith(viewRedactHistory: value);
     _viewRedactHistorySaveTimer?.cancel();
-    _viewRedactHistorySaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _viewRedactHistorySaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setMessageBubbleOpacity(double value) async {
@@ -1682,17 +1694,23 @@ class ThemeProvider with ChangeNotifier {
   Future<void> setUseDesktopLayout(bool value) async {
     _activeTheme = _activeTheme.copyWith(useDesktopLayout: value);
     _useDesktopLayoutSaveTimer?.cancel();
-    _useDesktopLayoutSaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _useDesktopLayoutSaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setUseAutoReplyColor(bool value) async {
     _activeTheme = _activeTheme.copyWith(useAutoReplyColor: value);
     _useAutoReplyColorSaveTimer?.cancel();
-    _useAutoReplyColorSaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _useAutoReplyColorSaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setCustomReplyColor(Color? color) async {
@@ -1764,9 +1782,12 @@ class ThemeProvider with ChangeNotifier {
   Future<void> setUseGradientForAddAccountButton(bool value) async {
     _activeTheme = _activeTheme.copyWith(useGradientForAddAccountButton: value);
     _useGradientForAddAccountButtonSaveTimer?.cancel();
-    _useGradientForAddAccountButtonSaveTimer = Timer(const Duration(milliseconds: 300), () async {
-      await _saveActiveTheme();
-    });
+    _useGradientForAddAccountButtonSaveTimer = Timer(
+      const Duration(milliseconds: 300),
+      () async {
+        await _saveActiveTheme();
+      },
+    );
   }
 
   Future<void> setAddAccountButtonGradientColor1(Color color) async {

--- a/lib/utils/theme_provider.dart
+++ b/lib/utils/theme_provider.dart
@@ -460,11 +460,11 @@ class CustomThemePreset {
       'id': id,
       'name': name,
       'appTheme': appTheme.index,
-      'accentColor': accentColor.value,
+      'accentColor': accentColor.toARGB32(),
       'useCustomChatWallpaper': useCustomChatWallpaper,
       'chatWallpaperType': chatWallpaperType.index,
-      'chatWallpaperColor1': chatWallpaperColor1.value,
-      'chatWallpaperColor2': chatWallpaperColor2.value,
+      'chatWallpaperColor1': chatWallpaperColor1.toARGB32(),
+      'chatWallpaperColor2': chatWallpaperColor2.toARGB32(),
       'chatWallpaperImagePath': chatWallpaperImagePath,
       'chatWallpaperVideoPath': chatWallpaperVideoPath,
       'chatWallpaperBlur': chatWallpaperBlur,
@@ -490,10 +490,10 @@ class CustomThemePreset {
       'messageShadowIntensity': messageShadowIntensity,
       'messageBorderRadius': messageBorderRadius,
       'messageFontSize': messageFontSize,
-      'myBubbleColorLight': myBubbleColorLight?.value,
-      'theirBubbleColorLight': theirBubbleColorLight?.value,
-      'myBubbleColorDark': myBubbleColorDark?.value,
-      'theirBubbleColorDark': theirBubbleColorDark?.value,
+      'myBubbleColorLight': myBubbleColorLight?.toARGB32(),
+      'theirBubbleColorLight': theirBubbleColorLight?.toARGB32(),
+      'myBubbleColorDark': myBubbleColorDark?.toARGB32(),
+      'theirBubbleColorDark': theirBubbleColorDark?.toARGB32(),
       'messageBubbleType': messageBubbleType.index,
       'sendOnEnter': sendOnEnter,
       'chatTransition': chatTransition.index,
@@ -507,7 +507,7 @@ class CustomThemePreset {
       'ultraOptimizeChats': ultraOptimizeChats,
       'useDesktopLayout': useDesktopLayout,
       'useAutoReplyColor': useAutoReplyColor,
-      'customReplyColor': customReplyColor?.value,
+      'customReplyColor': customReplyColor?.toARGB32(),
       'useGradientForChatsList': useGradientForChatsList,
       'chatsListBackgroundType': chatsListBackgroundType.index,
       'chatsListImagePath': chatsListImagePath,
@@ -521,16 +521,18 @@ class CustomThemePreset {
       'useGradientForFolderTabs': useGradientForFolderTabs,
       'folderTabsBackgroundType': folderTabsBackgroundType.index,
       'folderTabsImagePath': folderTabsImagePath,
-      'chatsListGradientColor1': chatsListGradientColor1.value,
-      'chatsListGradientColor2': chatsListGradientColor2.value,
-      'drawerGradientColor1': drawerGradientColor1.value,
-      'drawerGradientColor2': drawerGradientColor2.value,
-      'addAccountButtonGradientColor1': addAccountButtonGradientColor1.value,
-      'addAccountButtonGradientColor2': addAccountButtonGradientColor2.value,
-      'appBarGradientColor1': appBarGradientColor1.value,
-      'appBarGradientColor2': appBarGradientColor2.value,
-      'folderTabsGradientColor1': folderTabsGradientColor1.value,
-      'folderTabsGradientColor2': folderTabsGradientColor2.value,
+      'chatsListGradientColor1': chatsListGradientColor1.toARGB32(),
+      'chatsListGradientColor2': chatsListGradientColor2.toARGB32(),
+      'drawerGradientColor1': drawerGradientColor1.toARGB32(),
+      'drawerGradientColor2': drawerGradientColor2.toARGB32(),
+      'addAccountButtonGradientColor1': addAccountButtonGradientColor1
+          .toARGB32(),
+      'addAccountButtonGradientColor2': addAccountButtonGradientColor2
+          .toARGB32(),
+      'appBarGradientColor1': appBarGradientColor1.toARGB32(),
+      'appBarGradientColor2': appBarGradientColor2.toARGB32(),
+      'folderTabsGradientColor1': folderTabsGradientColor1.toARGB32(),
+      'folderTabsGradientColor2': folderTabsGradientColor2.toARGB32(),
     };
   }
 
@@ -545,15 +547,17 @@ class CustomThemePreset {
       id: json['id'] as String,
       name: json['name'] as String,
       appTheme: parsedTheme,
-      accentColor: Color(json['accentColor'] as int? ?? Colors.blue.value),
+      accentColor: Color(json['accentColor'] as int? ?? Colors.blue.toARGB32()),
       useCustomChatWallpaper: json['useCustomChatWallpaper'] as bool? ?? false,
       chatWallpaperType:
           ChatWallpaperType.values[json['chatWallpaperType'] as int? ?? 0],
       chatWallpaperColor1: Color(
-        json['chatWallpaperColor1'] as int? ?? const Color(0xFF101010).value,
+        json['chatWallpaperColor1'] as int? ??
+            const Color(0xFF101010).toARGB32(),
       ),
       chatWallpaperColor2: Color(
-        json['chatWallpaperColor2'] as int? ?? const Color(0xFF202020).value,
+        json['chatWallpaperColor2'] as int? ??
+            const Color(0xFF202020).toARGB32(),
       ),
       chatWallpaperImagePath: json['chatWallpaperImagePath'] as String?,
       chatWallpaperVideoPath: json['chatWallpaperVideoPath'] as String?,
@@ -658,39 +662,43 @@ class CustomThemePreset {
       folderTabsImagePath: json['folderTabsImagePath'] as String?,
       chatsListGradientColor1: Color(
         json['chatsListGradientColor1'] as int? ??
-            const Color(0xFF1E1E1E).value,
+            const Color(0xFF1E1E1E).toARGB32(),
       ),
       chatsListGradientColor2: Color(
         json['chatsListGradientColor2'] as int? ??
-            const Color(0xFF2D2D2D).value,
+            const Color(0xFF2D2D2D).toARGB32(),
       ),
       drawerGradientColor1: Color(
-        json['drawerGradientColor1'] as int? ?? const Color(0xFF1E1E1E).value,
+        json['drawerGradientColor1'] as int? ??
+            const Color(0xFF1E1E1E).toARGB32(),
       ),
       drawerGradientColor2: Color(
-        json['drawerGradientColor2'] as int? ?? const Color(0xFF2D2D2D).value,
+        json['drawerGradientColor2'] as int? ??
+            const Color(0xFF2D2D2D).toARGB32(),
       ),
       addAccountButtonGradientColor1: Color(
         json['addAccountButtonGradientColor1'] as int? ??
-            const Color(0xFF1E1E1E).value,
+            const Color(0xFF1E1E1E).toARGB32(),
       ),
       addAccountButtonGradientColor2: Color(
         json['addAccountButtonGradientColor2'] as int? ??
-            const Color(0xFF2D2D2D).value,
+            const Color(0xFF2D2D2D).toARGB32(),
       ),
       appBarGradientColor1: Color(
-        json['appBarGradientColor1'] as int? ?? const Color(0xFF1E1E1E).value,
+        json['appBarGradientColor1'] as int? ??
+            const Color(0xFF1E1E1E).toARGB32(),
       ),
       appBarGradientColor2: Color(
-        json['appBarGradientColor2'] as int? ?? const Color(0xFF2D2D2D).value,
+        json['appBarGradientColor2'] as int? ??
+            const Color(0xFF2D2D2D).toARGB32(),
       ),
       folderTabsGradientColor1: Color(
         json['folderTabsGradientColor1'] as int? ??
-            const Color(0xFF1E1E1E).value,
+            const Color(0xFF1E1E1E).toARGB32(),
       ),
       folderTabsGradientColor2: Color(
         json['folderTabsGradientColor2'] as int? ??
-            const Color(0xFF2D2D2D).value,
+            const Color(0xFF2D2D2D).toARGB32(),
       ),
     );
   }

--- a/lib/utils/user_id_lookup_screen.dart
+++ b/lib/utils/user_id_lookup_screen.dart
@@ -223,7 +223,7 @@ class _UserIdLookupScreenState extends State<UserIdLookupScreen> {
         style: TextStyle(
           color: hasData
               ? colors.onSurfaceVariant
-              : colors.onSurfaceVariant.withOpacity(0.7),
+              : colors.onSurfaceVariant.withValues(alpha: 0.7),
           fontStyle: hasData ? FontStyle.normal : FontStyle.italic,
         ),
       ),
@@ -241,7 +241,11 @@ class _UserIdLookupScreenState extends State<UserIdLookupScreen> {
       key: key,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Icon(icon, size: 64, color: colors.onSurfaceVariant.withOpacity(0.5)),
+        Icon(
+          icon,
+          size: 64,
+          color: colors.onSurfaceVariant.withValues(alpha: 0.5),
+        ),
         const SizedBox(height: 16),
         Text(
           title,
@@ -253,7 +257,7 @@ class _UserIdLookupScreenState extends State<UserIdLookupScreen> {
         Text(
           subtitle,
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-            color: colors.onSurfaceVariant.withOpacity(0.7),
+            color: colors.onSurfaceVariant.withValues(alpha: 0.7),
           ),
           textAlign: TextAlign.center,
         ),

--- a/lib/widgets/bottom_sheet_music_player.dart
+++ b/lib/widgets/bottom_sheet_music_player.dart
@@ -202,8 +202,8 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                   ? []
                   : [
                       BoxShadow(
-                        color: Colors.black.withOpacity(
-                          0.15 * _heightAnimation.value,
+                        color: Colors.black.withValues(
+                          alpha: 0.15 * _heightAnimation.value,
                         ),
                         blurRadius: 20,
                         offset: Offset(0, -6 * _heightAnimation.value),
@@ -340,7 +340,9 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                           track.artist,
                           style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.65),
+                                color: colorScheme.onSurface.withValues(
+                                  alpha: 0.65,
+                                ),
                                 fontSize: 13,
                               ),
                           maxLines: 1,
@@ -457,7 +459,7 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                               borderRadius: BorderRadius.circular(32),
                               boxShadow: [
                                 BoxShadow(
-                                  color: Colors.black.withOpacity(0.25),
+                                  color: Colors.black.withValues(alpha: 0.25),
                                   blurRadius: 30,
                                   offset: const Offset(0, 12),
                                   spreadRadius: 2,
@@ -513,7 +515,7 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                     Text(
                       track.artist,
                       style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        color: colorScheme.onSurface.withOpacity(0.75),
+                        color: colorScheme.onSurface.withValues(alpha: 0.75),
                         fontWeight: FontWeight.w500,
                       ),
                       textAlign: TextAlign.center,
@@ -525,7 +527,7 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                       Text(
                         track.album!,
                         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.6),
+                          color: colorScheme.onSurface.withValues(alpha: 0.6),
                         ),
                         textAlign: TextAlign.center,
                         maxLines: 1,
@@ -539,7 +541,7 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                           Duration(milliseconds: track.duration!),
                         ),
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.55),
+                          color: colorScheme.onSurface.withValues(alpha: 0.55),
                           fontWeight: FontWeight.w500,
                         ),
                         textAlign: TextAlign.center,
@@ -555,7 +557,9 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                             inactiveTrackColor:
                                 colorScheme.surfaceContainerHigh,
                             thumbColor: colorScheme.primary,
-                            overlayColor: colorScheme.primary.withOpacity(0.1),
+                            overlayColor: colorScheme.primary.withValues(
+                              alpha: 0.1,
+                            ),
                             thumbShape: const RoundSliderThumbShape(
                               enabledThumbRadius: 8,
                             ),
@@ -588,8 +592,8 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                                 _formatDuration(musicPlayer.position),
                                 style: Theme.of(context).textTheme.bodyMedium
                                     ?.copyWith(
-                                      color: colorScheme.onSurface.withOpacity(
-                                        0.7,
+                                      color: colorScheme.onSurface.withValues(
+                                        alpha: 0.7,
                                       ),
                                       fontWeight: FontWeight.w500,
                                       fontSize: 13,
@@ -599,8 +603,8 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                                 _formatDuration(musicPlayer.duration),
                                 style: Theme.of(context).textTheme.bodyMedium
                                     ?.copyWith(
-                                      color: colorScheme.onSurface.withOpacity(
-                                        0.7,
+                                      color: colorScheme.onSurface.withValues(
+                                        alpha: 0.7,
                                       ),
                                       fontWeight: FontWeight.w500,
                                       fontSize: 13,
@@ -717,7 +721,7 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                               ? Icons.volume_down_rounded
                               : Icons.volume_up_rounded,
                           size: 20,
-                          color: colorScheme.onSurface.withOpacity(0.7),
+                          color: colorScheme.onSurface.withValues(alpha: 0.7),
                         ),
                         const SizedBox(width: 12),
                         Expanded(
@@ -727,8 +731,8 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                               inactiveTrackColor:
                                   colorScheme.surfaceContainerHigh,
                               thumbColor: colorScheme.primary,
-                              overlayColor: colorScheme.primary.withOpacity(
-                                0.1,
+                              overlayColor: colorScheme.primary.withValues(
+                                alpha: 0.1,
                               ),
                               thumbShape: const RoundSliderThumbShape(
                                 enabledThumbRadius: 6,
@@ -749,7 +753,9 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
                           '${(musicPlayer.volume * 100).round()}%',
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.7),
+                                color: colorScheme.onSurface.withValues(
+                                  alpha: 0.7,
+                                ),
                                 fontWeight: FontWeight.w500,
                                 fontSize: 12,
                               ),
@@ -775,14 +781,14 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
           end: Alignment.bottomRight,
           colors: [
             colorScheme.primaryContainer,
-            colorScheme.primaryContainer.withOpacity(0.7),
+            colorScheme.primaryContainer.withValues(alpha: 0.7),
           ],
         ),
       ),
       child: Center(
         child: Icon(
           Icons.music_note_rounded,
-          color: colorScheme.onPrimaryContainer.withOpacity(0.7),
+          color: colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
           size: 32,
         ),
       ),
@@ -802,14 +808,14 @@ class _BottomSheetMusicPlayerState extends State<BottomSheetMusicPlayer>
           end: Alignment.bottomRight,
           colors: [
             colorScheme.primaryContainer,
-            colorScheme.primaryContainer.withOpacity(0.6),
+            colorScheme.primaryContainer.withValues(alpha: 0.6),
           ],
         ),
       ),
       child: Center(
         child: Icon(
           Icons.music_note_rounded,
-          color: colorScheme.onPrimaryContainer.withOpacity(0.6),
+          color: colorScheme.onPrimaryContainer.withValues(alpha: 0.6),
           size: 100,
         ),
       ),

--- a/lib/widgets/chat_message_bubble.dart
+++ b/lib/widgets/chat_message_bubble.dart
@@ -278,10 +278,10 @@ class ChatMessageBubble extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         decoration: BoxDecoration(
-          color: textColor.withOpacity(0.08 * messageTextOpacity),
+          color: textColor.withValues(alpha: 0.08 * messageTextOpacity),
           border: Border(
             left: BorderSide(
-              color: textColor.withOpacity(0.3 * messageTextOpacity),
+              color: textColor.withValues(alpha: 0.3 * messageTextOpacity),
               width: 3,
             ),
           ),
@@ -295,7 +295,7 @@ class ChatMessageBubble extends StatelessWidget {
                 Icon(
                   Icons.forward,
                   size: 14,
-                  color: textColor.withOpacity(0.6 * messageTextOpacity),
+                  color: textColor.withValues(alpha: 0.6 * messageTextOpacity),
                 ),
                 const SizedBox(width: 6),
                 if (forwardedSenderAvatarUrl != null)
@@ -306,7 +306,9 @@ class ChatMessageBubble extends StatelessWidget {
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       border: Border.all(
-                        color: textColor.withOpacity(0.2 * messageTextOpacity),
+                        color: textColor.withValues(
+                          alpha: 0.2 * messageTextOpacity,
+                        ),
                         width: 1,
                       ),
                     ),
@@ -316,14 +318,14 @@ class ChatMessageBubble extends StatelessWidget {
                         fit: BoxFit.cover,
                         errorBuilder: (context, error, stackTrace) {
                           return Container(
-                            color: textColor.withOpacity(
-                              0.1 * messageTextOpacity,
+                            color: textColor.withValues(
+                              alpha: 0.1 * messageTextOpacity,
                             ),
                             child: Icon(
                               Icons.person,
                               size: 12,
-                              color: textColor.withOpacity(
-                                0.5 * messageTextOpacity,
+                              color: textColor.withValues(
+                                alpha: 0.5 * messageTextOpacity,
                               ),
                             ),
                           );
@@ -338,16 +340,22 @@ class ChatMessageBubble extends StatelessWidget {
                     margin: const EdgeInsets.only(right: 6),
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: textColor.withOpacity(0.1 * messageTextOpacity),
+                      color: textColor.withValues(
+                        alpha: 0.1 * messageTextOpacity,
+                      ),
                       border: Border.all(
-                        color: textColor.withOpacity(0.2 * messageTextOpacity),
+                        color: textColor.withValues(
+                          alpha: 0.2 * messageTextOpacity,
+                        ),
                         width: 1,
                       ),
                     ),
                     child: Icon(
                       Icons.person,
                       size: 12,
-                      color: textColor.withOpacity(0.5 * messageTextOpacity),
+                      color: textColor.withValues(
+                        alpha: 0.5 * messageTextOpacity,
+                      ),
                     ),
                   ),
                 Flexible(
@@ -356,7 +364,9 @@ class ChatMessageBubble extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 13,
                       fontWeight: FontWeight.bold,
-                      color: textColor.withOpacity(0.9 * messageTextOpacity),
+                      color: textColor.withValues(
+                        alpha: 0.9 * messageTextOpacity,
+                      ),
                     ),
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -453,12 +463,16 @@ class ChatMessageBubble extends StatelessWidget {
                   }
 
                   final defaultTextStyle = TextStyle(
-                    color: textColor.withOpacity(0.9 * messageTextOpacity),
+                    color: textColor.withValues(
+                      alpha: 0.9 * messageTextOpacity,
+                    ),
                     fontSize: 14,
                   );
 
                   final linkStyle = TextStyle(
-                    color: textColor.withOpacity(0.9 * messageTextOpacity),
+                    color: textColor.withValues(
+                      alpha: 0.9 * messageTextOpacity,
+                    ),
                     fontSize: 14,
                     decoration: TextDecoration.underline,
                   );
@@ -518,8 +532,8 @@ class ChatMessageBubble extends StatelessWidget {
                           child: Icon(
                             Icons.lock,
                             size: 14,
-                            color: textColor.withOpacity(
-                              0.7 * messageTextOpacity,
+                            color: textColor.withValues(
+                              alpha: 0.7 * messageTextOpacity,
                             ),
                           ),
                         ),
@@ -678,8 +692,8 @@ class ChatMessageBubble extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
         decoration: BoxDecoration(
           color: isDarkMode
-              ? replyAccentColor.withOpacity(0.15)
-              : replyAccentColor.withOpacity(0.08),
+              ? replyAccentColor.withValues(alpha: 0.15)
+              : replyAccentColor.withValues(alpha: 0.08),
           borderRadius: BorderRadius.circular(
             (isUltraOptimized ? 4 : messageBorderRadius) * 0.3,
           ),
@@ -799,8 +813,10 @@ class ChatMessageBubble extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
                 color: isUserReaction
-                    ? Theme.of(context).colorScheme.primary.withOpacity(0.3)
-                    : textColor.withOpacity(0.1),
+                    ? Theme.of(
+                        context,
+                      ).colorScheme.primary.withValues(alpha: 0.3)
+                    : textColor.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(16),
               ),
               child: Row(
@@ -815,7 +831,7 @@ class ChatMessageBubble extends StatelessWidget {
                           : FontWeight.w500,
                       color: isUserReaction
                           ? Theme.of(context).colorScheme.primary
-                          : textColor.withOpacity(0.9),
+                          : textColor.withValues(alpha: 0.9),
                     ),
                   ),
                   if (isUserReaction && isReactionSending) ...[
@@ -836,7 +852,6 @@ class ChatMessageBubble extends StatelessWidget {
       ),
     );
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -1016,7 +1031,9 @@ class ChatMessageBubble extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(6),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.error.withValues(alpha: 0.1),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.error.withValues(alpha: 0.1),
                   shape: BoxShape.circle,
                 ),
                 child: Icon(
@@ -1026,14 +1043,17 @@ class ChatMessageBubble extends StatelessWidget {
                 ),
               ),
             ],
-            if (message.originalText != null && themeProvider.viewRedactHistory) ...[
+            if (message.originalText != null &&
+                themeProvider.viewRedactHistory) ...[
               const SizedBox(width: 8),
               GestureDetector(
                 onTap: () => _showRedactHistory(context),
                 child: Container(
                   padding: const EdgeInsets.all(6),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.1),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.secondary.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
                   child: Icon(
@@ -1096,8 +1116,8 @@ class ChatMessageBubble extends StatelessWidget {
                           vertical: 12,
                         ),
 
-                        backgroundColor: textColor.withOpacity(0.1),
-                        foregroundColor: textColor.withOpacity(0.9),
+                        backgroundColor: textColor.withValues(alpha: 0.1),
+                        foregroundColor: textColor.withValues(alpha: 0.9),
                       ),
                       child: Text(
                         text,
@@ -1219,7 +1239,7 @@ class ChatMessageBubble extends StatelessWidget {
                             color: getUserColor(
                               message.senderId,
                               context,
-                            ).withOpacity(0.8),
+                            ).withValues(alpha: 0.8),
                             fontSize: 12,
                           ),
                           maxLines: 1,
@@ -1253,7 +1273,7 @@ class ChatMessageBubble extends StatelessWidget {
                               '(изменено)',
                               style: TextStyle(
                                 fontSize: 10,
-                                color: textColor.withOpacity(0.5),
+                                color: textColor.withValues(alpha: 0.5),
                                 fontStyle: FontStyle.italic,
                               ),
                             ),
@@ -1289,7 +1309,7 @@ class ChatMessageBubble extends StatelessWidget {
                               '(изменено)',
                               style: TextStyle(
                                 fontSize: 10,
-                                color: textColor.withOpacity(0.5),
+                                color: textColor.withValues(alpha: 0.5),
                                 fontStyle: FontStyle.italic,
                               ),
                             ),
@@ -1306,7 +1326,6 @@ class ChatMessageBubble extends StatelessWidget {
       ],
     );
   }
-
 
   Widget _buildStickerOnlyMessage(BuildContext context) {
     final sticker = message.attaches.firstWhere((a) => a['_type'] == 'STICKER');
@@ -1367,12 +1386,15 @@ class ChatMessageBubble extends StatelessWidget {
                 ),
               ],
             ),
-            if (message.isDeleted && Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
+            if (message.isDeleted &&
+                Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
               const SizedBox(width: 8),
               Container(
                 padding: const EdgeInsets.all(6),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.error.withValues(alpha: 0.1),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.error.withValues(alpha: 0.1),
                   shape: BoxShape.circle,
                 ),
                 child: Icon(
@@ -1399,8 +1421,11 @@ class ChatMessageBubble extends StatelessWidget {
     Uint8List? previewBytes;
     if (previewDataRaw is List<int>) {
       // Ограничение на размер previewData для предотвращения зависания
-      if (previewDataRaw.length > 50000) { // 50KB limit
-        print('⚠️ PreviewData слишком большой (${previewDataRaw.length} bytes), пропускаем');
+      if (previewDataRaw.length > 50000) {
+        // 50KB limit
+        print(
+          '⚠️ PreviewData слишком большой (${previewDataRaw.length} bytes), пропускаем',
+        );
       } else {
         previewBytes = Uint8List.fromList(previewDataRaw);
       }
@@ -1470,12 +1495,15 @@ class ChatMessageBubble extends StatelessWidget {
                   ),
                 ],
               ),
-              if (message.isDeleted && Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
+              if (message.isDeleted &&
+                  Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
                 const SizedBox(width: 8),
                 Container(
                   padding: const EdgeInsets.all(6),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.error.withValues(alpha: 0.1),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.error.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
                   child: Icon(
@@ -1517,7 +1545,7 @@ class ChatMessageBubble extends StatelessWidget {
     required bool isUltraOptimized,
     required int senderId,
   }) {
-    final nameColor = getUserColor(senderId, context).withOpacity(0.8);
+    final nameColor = getUserColor(senderId, context).withValues(alpha: 0.8);
     final canReply = onReply != null && !isChannel;
     final screenWidth = MediaQuery.of(context).size.width;
     final hasSpaceForReply = screenWidth > 280;
@@ -1660,12 +1688,15 @@ class ChatMessageBubble extends StatelessWidget {
                   ],
                 ),
               ),
-              if (message.isDeleted && Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
+              if (message.isDeleted &&
+                  Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
                 const SizedBox(width: 8),
                 Container(
                   padding: const EdgeInsets.all(6),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.error.withValues(alpha: 0.1),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.error.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
                   child: Icon(
@@ -1841,12 +1872,17 @@ class ChatMessageBubble extends StatelessWidget {
                         ],
                       ),
                     ),
-                    if (message.isDeleted && Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
+                    if (message.isDeleted &&
+                        Provider.of<ThemeProvider>(
+                          context,
+                        ).showDeletedMessages) ...[
                       const SizedBox(width: 8),
                       Container(
                         padding: const EdgeInsets.all(6),
                         decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.1),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.error.withValues(alpha: 0.1),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -2000,12 +2036,15 @@ class ChatMessageBubble extends StatelessWidget {
                   ],
                 ),
               ),
-              if (message.isDeleted && Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
+              if (message.isDeleted &&
+                  Provider.of<ThemeProvider>(context).showDeletedMessages) ...[
                 const SizedBox(width: 8),
                 Container(
                   padding: const EdgeInsets.all(6),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.error.withValues(alpha: 0.1),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.error.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
                   child: Icon(
@@ -2139,8 +2178,11 @@ class ChatMessageBubble extends StatelessWidget {
         try {
           final intList = List<int>.from(previewDataRaw);
           // Ограничение на размер previewData для предотвращения зависания
-          if (intList.length > 50000) { // 50KB limit
-            print('⚠️ PreviewData слишком большой (${intList.length} bytes), пропускаем');
+          if (intList.length > 50000) {
+            // 50KB limit
+            print(
+              '⚠️ PreviewData слишком большой (${intList.length} bytes), пропускаем',
+            );
           } else {
             previewBytes = Uint8List.fromList(intList);
           }
@@ -2401,7 +2443,7 @@ class ChatMessageBubble extends StatelessWidget {
             : 'Звонок отменен';
         callText = callTypeText;
         callIcon = callType == 'VIDEO' ? Icons.videocam_off : Icons.call_end;
-        callColor = textColor.withOpacity(0.6);
+        callColor = textColor.withValues(alpha: 0.6);
         break;
 
       case 'REJECTED':
@@ -2410,21 +2452,21 @@ class ChatMessageBubble extends StatelessWidget {
             : 'Звонок отклонен';
         callText = callTypeText;
         callIcon = callType == 'VIDEO' ? Icons.videocam_off : Icons.call_end;
-        callColor = textColor.withOpacity(0.6);
+        callColor = textColor.withValues(alpha: 0.6);
         break;
 
       default:
         callText = callType == 'VIDEO' ? 'Видеозвонок' : 'Звонок';
         callIcon = callType == 'VIDEO' ? Icons.videocam : Icons.call;
-        callColor = textColor.withOpacity(0.6);
+        callColor = textColor.withValues(alpha: 0.6);
         break;
     }
 
     return Container(
       decoration: BoxDecoration(
-        color: callColor.withOpacity(0.1),
+        color: callColor.withValues(alpha: 0.1),
         borderRadius: borderRadius,
-        border: Border.all(color: callColor.withOpacity(0.3), width: 1),
+        border: Border.all(color: callColor.withValues(alpha: 0.3), width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.all(12),
@@ -2434,7 +2476,7 @@ class ChatMessageBubble extends StatelessWidget {
               width: 48,
               height: 48,
               decoration: BoxDecoration(
-                color: callColor.withOpacity(0.2),
+                color: callColor.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Icon(callIcon, color: callColor, size: 24),
@@ -2629,10 +2671,10 @@ class ChatMessageBubble extends StatelessWidget {
       constraints: BoxConstraints(maxWidth: maxContactWidth),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: textColor.withOpacity(0.1 * messageTextOpacity),
+        color: textColor.withValues(alpha: 0.1 * messageTextOpacity),
         borderRadius: BorderRadius.circular(isUltraOptimized ? 8 : 12),
         border: Border.all(
-          color: textColor.withOpacity(0.2 * messageTextOpacity),
+          color: textColor.withValues(alpha: 0.2 * messageTextOpacity),
         ),
       ),
       child: Row(
@@ -2654,12 +2696,12 @@ class ChatMessageBubble extends StatelessWidget {
                           width: 40,
                           height: 40,
                           decoration: BoxDecoration(
-                            color: textColor.withOpacity(0.2),
+                            color: textColor.withValues(alpha: 0.2),
                             shape: BoxShape.circle,
                           ),
                           child: Icon(
                             Icons.person,
-                            color: textColor.withOpacity(0.6),
+                            color: textColor.withValues(alpha: 0.6),
                           ),
                         );
                       },
@@ -2669,12 +2711,12 @@ class ChatMessageBubble extends StatelessWidget {
                     width: 40,
                     height: 40,
                     decoration: BoxDecoration(
-                      color: textColor.withOpacity(0.2),
+                      color: textColor.withValues(alpha: 0.2),
                       shape: BoxShape.circle,
                     ),
                     child: Icon(
                       Icons.person,
-                      color: textColor.withOpacity(0.6),
+                      color: textColor.withValues(alpha: 0.6),
                     ),
                   ),
           ),
@@ -2690,7 +2732,7 @@ class ChatMessageBubble extends StatelessWidget {
                   Text(
                     displayName,
                     style: TextStyle(
-                      color: textColor.withOpacity(messageTextOpacity),
+                      color: textColor.withValues(alpha: messageTextOpacity),
                       fontWeight: FontWeight.w600,
                       fontSize: 16,
                     ),
@@ -2701,7 +2743,9 @@ class ChatMessageBubble extends StatelessWidget {
                     Text(
                       contact.description!,
                       style: TextStyle(
-                        color: textColor.withOpacity(0.7 * messageTextOpacity),
+                        color: textColor.withValues(
+                          alpha: 0.7 * messageTextOpacity,
+                        ),
                         fontSize: 14,
                       ),
                       maxLines: 2,
@@ -2761,9 +2805,12 @@ class ChatMessageBubble extends StatelessWidget {
           child: Container(
             constraints: BoxConstraints(maxWidth: maxFileWidth),
             decoration: BoxDecoration(
-              color: textColor.withOpacity(0.05),
+              color: textColor.withValues(alpha: 0.05),
               borderRadius: borderRadius,
-              border: Border.all(color: textColor.withOpacity(0.1), width: 1),
+              border: Border.all(
+                color: textColor.withValues(alpha: 0.1),
+                width: 1,
+              ),
             ),
             child: Padding(
               padding: const EdgeInsets.all(12),
@@ -2774,12 +2821,12 @@ class ChatMessageBubble extends StatelessWidget {
                     width: 48,
                     height: 48,
                     decoration: BoxDecoration(
-                      color: textColor.withOpacity(0.1),
+                      color: textColor.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Icon(
                       iconData,
-                      color: textColor.withOpacity(0.8),
+                      color: textColor.withValues(alpha: 0.8),
                       size: 24,
                     ),
                   ),
@@ -2808,7 +2855,7 @@ class ChatMessageBubble extends StatelessWidget {
                                 return Text(
                                   sizeStr,
                                   style: TextStyle(
-                                    color: textColor.withOpacity(0.6),
+                                    color: textColor.withValues(alpha: 0.6),
                                     fontSize: 12,
                                   ),
                                 );
@@ -2819,15 +2866,15 @@ class ChatMessageBubble extends StatelessWidget {
                                     LinearProgressIndicator(
                                       value: progress,
                                       minHeight: 3,
-                                      backgroundColor: textColor.withOpacity(
-                                        0.1,
+                                      backgroundColor: textColor.withValues(
+                                        alpha: 0.1,
                                       ),
                                     ),
                                     const SizedBox(height: 4),
                                     Text(
                                       '${(progress * 100).toStringAsFixed(0)}%',
                                       style: TextStyle(
-                                        color: textColor.withOpacity(0.6),
+                                        color: textColor.withValues(alpha: 0.6),
                                         fontSize: 11,
                                       ),
                                     ),
@@ -2839,13 +2886,17 @@ class ChatMessageBubble extends StatelessWidget {
                                     Icon(
                                       Icons.check_circle,
                                       size: 12,
-                                      color: Colors.green.withOpacity(0.8),
+                                      color: Colors.green.withValues(
+                                        alpha: 0.8,
+                                      ),
                                     ),
                                     const SizedBox(width: 4),
                                     Text(
                                       'Загружено',
                                       style: TextStyle(
-                                        color: Colors.green.withOpacity(0.8),
+                                        color: Colors.green.withValues(
+                                          alpha: 0.8,
+                                        ),
                                         fontSize: 11,
                                       ),
                                     ),
@@ -2858,7 +2909,7 @@ class ChatMessageBubble extends StatelessWidget {
                           Text(
                             sizeStr,
                             style: TextStyle(
-                              color: textColor.withOpacity(0.6),
+                              color: textColor.withValues(alpha: 0.6),
                               fontSize: 12,
                             ),
                           ),
@@ -2878,7 +2929,7 @@ class ChatMessageBubble extends StatelessWidget {
                         }
                         return Icon(
                           Icons.download_outlined,
-                          color: textColor.withOpacity(0.6),
+                          color: textColor.withValues(alpha: 0.6),
                           size: 20,
                         );
                       },
@@ -2886,7 +2937,7 @@ class ChatMessageBubble extends StatelessWidget {
                   else
                     Icon(
                       Icons.download_outlined,
-                      color: textColor.withOpacity(0.6),
+                      color: textColor.withValues(alpha: 0.6),
                       size: 20,
                     ),
                 ],
@@ -2962,9 +3013,12 @@ class ChatMessageBubble extends StatelessWidget {
                 : 300.0,
           ),
           decoration: BoxDecoration(
-            color: textColor.withOpacity(0.05),
+            color: textColor.withValues(alpha: 0.05),
             borderRadius: borderRadius,
-            border: Border.all(color: textColor.withOpacity(0.1), width: 1),
+            border: Border.all(
+              color: textColor.withValues(alpha: 0.1),
+              width: 1,
+            ),
           ),
           child: Padding(
             padding: const EdgeInsets.all(12),
@@ -2976,20 +3030,20 @@ class ChatMessageBubble extends StatelessWidget {
                   child: Container(
                     width: 56,
                     height: 56,
-                    color: textColor.withOpacity(0.1),
+                    color: textColor.withValues(alpha: 0.1),
                     child: albumArtUrl != null
                         ? Image.network(
                             albumArtUrl,
                             fit: BoxFit.cover,
                             errorBuilder: (context, error, stackTrace) => Icon(
                               Icons.music_note,
-                              color: textColor.withOpacity(0.8),
+                              color: textColor.withValues(alpha: 0.8),
                               size: 24,
                             ),
                           )
                         : Icon(
                             Icons.music_note,
-                            color: textColor.withOpacity(0.8),
+                            color: textColor.withValues(alpha: 0.8),
                             size: 24,
                           ),
                   ),
@@ -3014,7 +3068,7 @@ class ChatMessageBubble extends StatelessWidget {
                       Text(
                         artist,
                         style: TextStyle(
-                          color: textColor.withOpacity(0.7),
+                          color: textColor.withValues(alpha: 0.7),
                           fontSize: 12,
                         ),
                         maxLines: 1,
@@ -3025,7 +3079,7 @@ class ChatMessageBubble extends StatelessWidget {
                         Text(
                           album,
                           style: TextStyle(
-                            color: textColor.withOpacity(0.6),
+                            color: textColor.withValues(alpha: 0.6),
                             fontSize: 11,
                           ),
                           maxLines: 1,
@@ -3039,7 +3093,7 @@ class ChatMessageBubble extends StatelessWidget {
                             Text(
                               durationText,
                               style: TextStyle(
-                                color: textColor.withOpacity(0.6),
+                                color: textColor.withValues(alpha: 0.6),
                                 fontSize: 11,
                               ),
                             ),
@@ -3047,7 +3101,7 @@ class ChatMessageBubble extends StatelessWidget {
                             Text(
                               '•',
                               style: TextStyle(
-                                color: textColor.withOpacity(0.6),
+                                color: textColor.withValues(alpha: 0.6),
                                 fontSize: 11,
                               ),
                             ),
@@ -3056,7 +3110,7 @@ class ChatMessageBubble extends StatelessWidget {
                           Text(
                             sizeStr,
                             style: TextStyle(
-                              color: textColor.withOpacity(0.6),
+                              color: textColor.withValues(alpha: 0.6),
                               fontSize: 11,
                             ),
                           ),
@@ -3067,7 +3121,7 @@ class ChatMessageBubble extends StatelessWidget {
                 ),
                 Icon(
                   Icons.download_outlined,
-                  color: textColor.withOpacity(0.6),
+                  color: textColor.withValues(alpha: 0.6),
                   size: 20,
                 ),
               ],
@@ -3164,9 +3218,12 @@ class ChatMessageBubble extends StatelessWidget {
                     : 300.0,
               ),
               decoration: BoxDecoration(
-                color: textColor.withOpacity(0.05),
+                color: textColor.withValues(alpha: 0.05),
                 borderRadius: borderRadius,
-                border: Border.all(color: textColor.withOpacity(0.1), width: 1),
+                border: Border.all(
+                  color: textColor.withValues(alpha: 0.1),
+                  width: 1,
+                ),
               ),
               child: Padding(
                 padding: const EdgeInsets.all(12),
@@ -3178,7 +3235,7 @@ class ChatMessageBubble extends StatelessWidget {
                       child: Container(
                         width: 56,
                         height: 56,
-                        color: textColor.withOpacity(0.1),
+                        color: textColor.withValues(alpha: 0.1),
                         child: albumArtUrl != null
                             ? Image.network(
                                 albumArtUrl,
@@ -3186,13 +3243,13 @@ class ChatMessageBubble extends StatelessWidget {
                                 errorBuilder: (context, error, stackTrace) =>
                                     Icon(
                                       Icons.music_note,
-                                      color: textColor.withOpacity(0.8),
+                                      color: textColor.withValues(alpha: 0.8),
                                       size: 24,
                                     ),
                               )
                             : Icon(
                                 Icons.music_note,
-                                color: textColor.withOpacity(0.8),
+                                color: textColor.withValues(alpha: 0.8),
                                 size: 24,
                               ),
                       ),
@@ -3217,7 +3274,7 @@ class ChatMessageBubble extends StatelessWidget {
                           Text(
                             artist,
                             style: TextStyle(
-                              color: textColor.withOpacity(0.7),
+                              color: textColor.withValues(alpha: 0.7),
                               fontSize: 12,
                             ),
                             maxLines: 1,
@@ -3228,7 +3285,7 @@ class ChatMessageBubble extends StatelessWidget {
                             Text(
                               album,
                               style: TextStyle(
-                                color: textColor.withOpacity(0.6),
+                                color: textColor.withValues(alpha: 0.6),
                                 fontSize: 11,
                               ),
                               maxLines: 1,
@@ -3243,7 +3300,7 @@ class ChatMessageBubble extends StatelessWidget {
                                   Text(
                                     durationText,
                                     style: TextStyle(
-                                      color: textColor.withOpacity(0.6),
+                                      color: textColor.withValues(alpha: 0.6),
                                       fontSize: 11,
                                     ),
                                   ),
@@ -3251,7 +3308,7 @@ class ChatMessageBubble extends StatelessWidget {
                                   Text(
                                     '•',
                                     style: TextStyle(
-                                      color: textColor.withOpacity(0.6),
+                                      color: textColor.withValues(alpha: 0.6),
                                       fontSize: 11,
                                     ),
                                   ),
@@ -3260,7 +3317,7 @@ class ChatMessageBubble extends StatelessWidget {
                                 Text(
                                   sizeStr,
                                   style: TextStyle(
-                                    color: textColor.withOpacity(0.6),
+                                    color: textColor.withValues(alpha: 0.6),
                                     fontSize: 11,
                                   ),
                                 ),
@@ -3273,13 +3330,15 @@ class ChatMessageBubble extends StatelessWidget {
                                 LinearProgressIndicator(
                                   value: progress,
                                   minHeight: 3,
-                                  backgroundColor: textColor.withOpacity(0.1),
+                                  backgroundColor: textColor.withValues(
+                                    alpha: 0.1,
+                                  ),
                                 ),
                                 const SizedBox(height: 4),
                                 Text(
                                   '${(progress * 100).toStringAsFixed(0)}%',
                                   style: TextStyle(
-                                    color: textColor.withOpacity(0.6),
+                                    color: textColor.withValues(alpha: 0.6),
                                     fontSize: 11,
                                   ),
                                 ),
@@ -3291,13 +3350,13 @@ class ChatMessageBubble extends StatelessWidget {
                                 Icon(
                                   Icons.check_circle,
                                   size: 12,
-                                  color: Colors.green.withOpacity(0.8),
+                                  color: Colors.green.withValues(alpha: 0.8),
                                 ),
                                 const SizedBox(width: 4),
                                 Text(
                                   'Загружено',
                                   style: TextStyle(
-                                    color: Colors.green.withOpacity(0.8),
+                                    color: Colors.green.withValues(alpha: 0.8),
                                     fontSize: 11,
                                   ),
                                 ),
@@ -3316,7 +3375,7 @@ class ChatMessageBubble extends StatelessWidget {
                             onPressed: handleTap,
                             icon: Icon(
                               Icons.download_outlined,
-                              color: textColor.withOpacity(0.6),
+                              color: textColor.withValues(alpha: 0.6),
                               size: 20,
                             ),
                           ),
@@ -4057,7 +4116,7 @@ class ChatMessageBubble extends StatelessWidget {
                             onTap: () => _openPhotoGallery(context, photos, 3),
                             child: Container(
                               decoration: BoxDecoration(
-                                color: Colors.black.withOpacity(0.6),
+                                color: Colors.black.withValues(alpha: 0.6),
                                 borderRadius: borderRadius,
                               ),
                               child: Center(
@@ -4290,7 +4349,7 @@ class ChatMessageBubble extends StatelessWidget {
                     (isDark
                         ? const Color(0xFF182533)
                         : const Color(0xFF464646))));
-    return baseColor.withOpacity(1.0 - messageOpacity);
+    return baseColor.withValues(alpha: 1.0 - messageOpacity);
   }
 
   Color _getTextColor(
@@ -4309,7 +4368,7 @@ class ChatMessageBubble extends StatelessWidget {
         ? (isMe ? scheme.onPrimaryContainer : scheme.onSecondaryContainer)
         : (isDarkMode ? Colors.white : Colors.black);
 
-    return base.withOpacity(messageTextOpacity.clamp(0.0, 1.0));
+    return base.withValues(alpha: messageTextOpacity.clamp(0.0, 1.0));
   }
 
   List<Widget> _buildMessageContentChildren(
@@ -4324,9 +4383,13 @@ class ChatMessageBubble extends StatelessWidget {
     VoidCallback onSenderNameTap,
   ) {
     // Ограничение на количество attaches для предотвращения зависания
-    final attachesToShow = message.attaches.take(10).toList(); // Максимум 10 attaches
+    final attachesToShow = message.attaches
+        .take(10)
+        .toList(); // Максимум 10 attaches
     if (message.attaches.length > attachesToShow.length) {
-      print('⚠️ Слишком много attaches (${message.attaches.length}), показываем только первые ${attachesToShow.length}');
+      print(
+        '⚠️ Слишком много attaches (${message.attaches.length}), показываем только первые ${attachesToShow.length}',
+      );
     }
 
     return [
@@ -4345,7 +4408,7 @@ class ChatMessageBubble extends StatelessWidget {
                   color: getUserColor(
                     message.senderId,
                     context,
-                  ).withOpacity(0.8),
+                  ).withValues(alpha: 0.8),
                   fontSize: 12,
                 ),
                 maxLines: 1,
@@ -4465,7 +4528,7 @@ class ChatMessageBubble extends StatelessWidget {
                   child: Icon(
                     Icons.lock,
                     size: 14,
-                    color: textColor.withOpacity(0.7),
+                    color: textColor.withValues(alpha: 0.7),
                   ),
                 ),
                 _buildMixedMessageContent(
@@ -4539,8 +4602,8 @@ class ChatMessageBubble extends StatelessWidget {
                         child: LinearProgressIndicator(
                           value: value,
                           backgroundColor: Colors.transparent,
-                          color: textColor.withOpacity(
-                            0.7 * messageTextOpacity,
+                          color: textColor.withValues(
+                            alpha: 0.7 * messageTextOpacity,
                           ),
                           minHeight: 3,
                         ),
@@ -4556,7 +4619,7 @@ class ChatMessageBubble extends StatelessWidget {
                 '(изменено)',
                 style: TextStyle(
                   fontSize: 10,
-                  color: textColor.withOpacity(0.5 * messageTextOpacity),
+                  color: textColor.withValues(alpha: 0.5 * messageTextOpacity),
                   fontStyle: FontStyle.italic,
                 ),
               ),
@@ -4614,7 +4677,7 @@ class ChatMessageBubble extends StatelessWidget {
                 '(изменено)',
                 style: TextStyle(
                   fontSize: 10,
-                  color: textColor.withOpacity(0.5 * messageTextOpacity),
+                  color: textColor.withValues(alpha: 0.5 * messageTextOpacity),
                   fontStyle: FontStyle.italic,
                 ),
               ),
@@ -4755,7 +4818,9 @@ class ChatMessageBubble extends StatelessWidget {
     // Ограничение на размер текста для предотвращения зависания
     const int maxTextLength = 10000; // 10KB limit for text
     if (text.length > maxTextLength) {
-      print('⚠️ Сообщение слишком большое (${text.length} символов), обрезаем до $maxTextLength');
+      print(
+        '⚠️ Сообщение слишком большое (${text.length} символов), обрезаем до $maxTextLength',
+      );
       text = text.substring(0, maxTextLength) + '... (сообщение обрезано)';
     }
 
@@ -4949,7 +5014,7 @@ class ChatMessageBubble extends StatelessWidget {
       borderRadius: BorderRadius.circular(messageBorderRadius),
       boxShadow: [
         BoxShadow(
-          color: Colors.black.withOpacity(messageShadowIntensity),
+          color: Colors.black.withValues(alpha: messageShadowIntensity),
           blurRadius: 8,
           spreadRadius: 0,
           offset: const Offset(0, 2),
@@ -4971,7 +5036,9 @@ class ChatMessageBubble extends StatelessWidget {
 
     return Container(
       constraints: BoxConstraints(
-        maxWidth: MediaQuery.of(context).size.width * 0.8, // Increased from 0.65 to 0.8
+        maxWidth:
+            MediaQuery.of(context).size.width *
+            0.8, // Increased from 0.65 to 0.8
         minWidth: 0, // Allow shrinking to zero
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4.5),
@@ -5026,7 +5093,8 @@ class ChatMessageBubble extends StatelessWidget {
   }
 
   void _showRedactHistory(BuildContext context) {
-    final hasOriginalText = message.originalText != null && message.originalText!.isNotEmpty;
+    final hasOriginalText =
+        message.originalText != null && message.originalText!.isNotEmpty;
 
     showDialog(
       context: context,
@@ -5049,7 +5117,9 @@ class ChatMessageBubble extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surfaceVariant.withValues(alpha: 0.3),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceVariant.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -5072,7 +5142,9 @@ class ChatMessageBubble extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: 0.3),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.secondaryContainer.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -5298,11 +5370,11 @@ class _VideoPreviewWidgetState extends State<_VideoPreviewWidget>
                       ),
                 Container(
                   decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.15),
+                    color: Colors.black.withValues(alpha: 0.15),
                   ),
                   child: Icon(
                     Icons.play_circle_filled_outlined,
-                    color: Colors.white.withOpacity(0.95),
+                    color: Colors.white.withValues(alpha: 0.95),
                     size: 50,
                     shadows: const [
                       Shadow(
@@ -6129,7 +6201,7 @@ class _MessageContextMenuState extends State<_MessageContextMenu>
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () => Navigator.of(context).pop(),
-              child: Container(color: Colors.black.withOpacity(0.1)),
+              child: Container(color: Colors.black.withValues(alpha: 0.1)),
             ),
           ),
           Positioned(
@@ -6156,8 +6228,8 @@ class _MessageContextMenuState extends State<_MessageContextMenu>
                       key: _menuKey,
                       elevation: 8,
                       margin: EdgeInsets.zero,
-                      color: theme.colorScheme.surface.withOpacity(
-                        themeProvider.messageMenuOpacity,
+                      color: theme.colorScheme.surface.withValues(
+                        alpha: themeProvider.messageMenuOpacity,
                       ),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(16),
@@ -6767,7 +6839,7 @@ class _FullScreenPhotoViewerState extends State<FullScreenPhotoViewer> {
               right: 0,
               child: Container(
                 height: 100,
-                color: Colors.black.withOpacity(0.7),
+                color: Colors.black.withValues(alpha: 0.7),
                 child: Stack(
                   children: [
                     ListView.builder(
@@ -6827,7 +6899,7 @@ class _FullScreenPhotoViewerState extends State<FullScreenPhotoViewer> {
                               begin: Alignment.centerLeft,
                               end: Alignment.centerRight,
                               colors: [
-                                Colors.black.withOpacity(0.7),
+                                Colors.black.withValues(alpha: 0.7),
                                 Colors.transparent,
                               ],
                             ),
@@ -6854,7 +6926,7 @@ class _FullScreenPhotoViewerState extends State<FullScreenPhotoViewer> {
                               begin: Alignment.centerRight,
                               end: Alignment.centerLeft,
                               colors: [
-                                Colors.black.withOpacity(0.7),
+                                Colors.black.withValues(alpha: 0.7),
                                 Colors.transparent,
                               ],
                             ),
@@ -7226,7 +7298,7 @@ class _FullScreenPhotoGalleryState extends State<FullScreenPhotoGallery> {
                           vertical: 6,
                         ),
                         decoration: BoxDecoration(
-                          color: Colors.black.withOpacity(0.6),
+                          color: Colors.black.withValues(alpha: 0.6),
                           borderRadius: BorderRadius.circular(20),
                         ),
                         child: Text(
@@ -7312,7 +7384,7 @@ class _FullScreenPhotoGalleryState extends State<FullScreenPhotoGallery> {
                       end: Alignment.bottomCenter,
                       colors: [
                         Colors.transparent,
-                        Colors.black.withOpacity(0.7),
+                        Colors.black.withValues(alpha: 0.7),
                       ],
                     ),
                   ),
@@ -7356,7 +7428,7 @@ class _FullScreenPhotoGalleryState extends State<FullScreenPhotoGallery> {
                   border: Border.all(
                     color: isCurrent
                         ? Colors.white
-                        : Colors.white.withOpacity(0.3),
+                        : Colors.white.withValues(alpha: 0.3),
                     width: isCurrent ? 3 : 1,
                   ),
                 ),
@@ -7379,7 +7451,10 @@ class _FullScreenPhotoGalleryState extends State<FullScreenPhotoGallery> {
                 gradient: LinearGradient(
                   begin: Alignment.centerLeft,
                   end: Alignment.centerRight,
-                  colors: [Colors.black.withOpacity(0.7), Colors.transparent],
+                  colors: [
+                    Colors.black.withValues(alpha: 0.7),
+                    Colors.transparent,
+                  ],
                 ),
               ),
               child: IconButton(
@@ -7403,7 +7478,10 @@ class _FullScreenPhotoGalleryState extends State<FullScreenPhotoGallery> {
                 gradient: LinearGradient(
                   begin: Alignment.centerRight,
                   end: Alignment.centerLeft,
-                  colors: [Colors.black.withOpacity(0.7), Colors.transparent],
+                  colors: [
+                    Colors.black.withValues(alpha: 0.7),
+                    Colors.transparent,
+                  ],
                 ),
               ),
               child: IconButton(
@@ -7836,10 +7914,10 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
       onLongPress: () {},
       child: Container(
         decoration: BoxDecoration(
-          color: widget.textColor.withOpacity(0.05),
+          color: widget.textColor.withValues(alpha: 0.05),
           borderRadius: widget.borderRadius,
           border: Border.all(
-            color: widget.textColor.withOpacity(0.1),
+            color: widget.textColor.withValues(alpha: 0.1),
             width: 1,
           ),
         ),
@@ -7854,7 +7932,7 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
                   width: 40,
                   height: 40,
                   decoration: BoxDecoration(
-                    color: widget.textColor.withOpacity(0.1),
+                    color: widget.textColor.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
                   child: _isLoading
@@ -7865,8 +7943,8 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
                         )
                       : Icon(
                           _isPlaying ? Icons.pause : Icons.play_arrow,
-                          color: widget.textColor.withOpacity(
-                            0.8 * widget.messageTextOpacity,
+                          color: widget.textColor.withValues(
+                            alpha: 0.8 * widget.messageTextOpacity,
                           ),
                           size: 24,
                         ),
@@ -7885,11 +7963,11 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
                           painter: _WaveformPainter(
                             waveform: _waveformData!,
                             progress: progress,
-                            color: widget.textColor.withOpacity(
-                              0.6 * widget.messageTextOpacity,
+                            color: widget.textColor.withValues(
+                              alpha: 0.6 * widget.messageTextOpacity,
                             ),
-                            progressColor: widget.textColor.withOpacity(
-                              0.9 * widget.messageTextOpacity,
+                            progressColor: widget.textColor.withValues(
+                              alpha: 0.9 * widget.messageTextOpacity,
                             ),
                           ),
                           child: LayoutBuilder(
@@ -7921,14 +7999,16 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
                     else
                       SliderTheme(
                         data: SliderTheme.of(context).copyWith(
-                          activeTrackColor: widget.textColor.withOpacity(
-                            0.8 * widget.messageTextOpacity,
+                          activeTrackColor: widget.textColor.withValues(
+                            alpha: 0.8 * widget.messageTextOpacity,
                           ),
-                          inactiveTrackColor: widget.textColor.withOpacity(0.1),
-                          thumbColor: widget.textColor.withOpacity(
-                            0.9 * widget.messageTextOpacity,
+                          inactiveTrackColor: widget.textColor.withValues(
+                            alpha: 0.1,
                           ),
-                          overlayColor: widget.textColor.withOpacity(0.1),
+                          thumbColor: widget.textColor.withValues(
+                            alpha: 0.9 * widget.messageTextOpacity,
+                          ),
+                          overlayColor: widget.textColor.withValues(alpha: 0.1),
                           thumbShape: const RoundSliderThumbShape(
                             enabledThumbRadius: 6,
                           ),
@@ -7953,8 +8033,8 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
                         Text(
                           _formatDuration(_position),
                           style: TextStyle(
-                            color: widget.textColor.withOpacity(
-                              0.7 * widget.messageTextOpacity,
+                            color: widget.textColor.withValues(
+                              alpha: 0.7 * widget.messageTextOpacity,
                             ),
                             fontSize: 12,
                           ),
@@ -7964,8 +8044,8 @@ class _AudioPlayerWidgetState extends State<_AudioPlayerWidget> {
                               ? _formatDuration(_totalDuration)
                               : widget.durationText,
                           style: TextStyle(
-                            color: widget.textColor.withOpacity(
-                              0.7 * widget.messageTextOpacity,
+                            color: widget.textColor.withValues(
+                              alpha: 0.7 * widget.messageTextOpacity,
                             ),
                             fontSize: 12,
                           ),
@@ -8211,7 +8291,7 @@ class _VideoCirclePlayerState extends State<_VideoCirclePlayer> {
 
               if (_isLoading)
                 Container(
-                  color: Colors.black.withOpacity(0.3),
+                  color: Colors.black.withValues(alpha: 0.3),
                   child: const Center(
                     child: CircularProgressIndicator(
                       color: Colors.white,
@@ -8229,7 +8309,7 @@ class _VideoCirclePlayerState extends State<_VideoCirclePlayer> {
                   duration: const Duration(milliseconds: 200),
                   child: Container(
                     decoration: BoxDecoration(
-                      color: Colors.black.withOpacity(0.3),
+                      color: Colors.black.withValues(alpha: 0.3),
                       shape: BoxShape.circle,
                     ),
                     child: Icon(

--- a/lib/widgets/chat_message_bubble.dart
+++ b/lib/widgets/chat_message_bubble.dart
@@ -5117,9 +5117,8 @@ class ChatMessageBubble extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.surfaceVariant.withValues(alpha: 0.3),
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest
+                        .withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(

--- a/lib/widgets/chat_message_bubble.dart
+++ b/lib/widgets/chat_message_bubble.dart
@@ -4869,7 +4869,8 @@ class ChatMessageBubble extends StatelessWidget {
               child: GalaxyAnimatedText(text: seg.text),
             );
           case KometSegmentType.pulse:
-            final hexStr = seg.color!.value
+            final hexStr = seg.color!
+                .toARGB32()
                 .toRadixString(16)
                 .padLeft(8, '0')
                 .substring(2)

--- a/lib/widgets/full_screen_video_player.dart
+++ b/lib/widgets/full_screen_video_player.dart
@@ -277,7 +277,7 @@ class _FullScreenVideoPlayerState extends State<FullScreenVideoPlayer>
                     child: Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
-                        color: Colors.black.withOpacity(0.7),
+                        color: Colors.black.withValues(alpha: 0.7),
                         borderRadius: BorderRadius.circular(16),
                       ),
                       child: Column(
@@ -428,10 +428,10 @@ class _VideoControls extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            Colors.black.withOpacity(0.7),
+            Colors.black.withValues(alpha: 0.7),
             Colors.transparent,
             Colors.transparent,
-            Colors.black.withOpacity(0.7),
+            Colors.black.withValues(alpha: 0.7),
           ],
         ),
       ),
@@ -446,7 +446,7 @@ class _VideoControls extends StatelessWidget {
                     onPressed: onBack,
                     icon: const Icon(Icons.arrow_back),
                     style: IconButton.styleFrom(
-                      backgroundColor: Colors.black.withOpacity(0.5),
+                      backgroundColor: Colors.black.withValues(alpha: 0.5),
                       foregroundColor: Colors.white,
                       shape: const CircleBorder(),
                     ),
@@ -455,7 +455,7 @@ class _VideoControls extends StatelessWidget {
                   FilledButton.tonal(
                     onPressed: onSpeedTap,
                     style: FilledButton.styleFrom(
-                      backgroundColor: Colors.black.withOpacity(0.5),
+                      backgroundColor: Colors.black.withValues(alpha: 0.5),
                       foregroundColor: Colors.white,
                       padding: const EdgeInsets.symmetric(
                         horizontal: 16,
@@ -593,7 +593,7 @@ class _MaterialYouControlButton extends StatelessWidget {
       return FilledButton.tonal(
         onPressed: onTap,
         style: FilledButton.styleFrom(
-          backgroundColor: Colors.white.withOpacity(0.16),
+          backgroundColor: Colors.white.withValues(alpha: 0.16),
           foregroundColor: Colors.white,
           padding: const EdgeInsets.all(14),
           shape: const CircleBorder(),
@@ -711,7 +711,7 @@ class _CustomProgressBarState extends State<_CustomProgressBar> {
                   child: Container(
                     height: 4,
                     decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.3),
+                      color: Colors.white.withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
@@ -743,7 +743,7 @@ class _CustomProgressBarState extends State<_CustomProgressBar> {
                         width: bufferedWidthPx,
                         height: 4,
                         decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.5),
+                          color: Colors.white.withValues(alpha: 0.5),
                           borderRadius: BorderRadius.circular(2),
                         ),
                       ),
@@ -776,7 +776,7 @@ class _CustomProgressBarState extends State<_CustomProgressBar> {
                         shape: BoxShape.circle,
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.3),
+                            color: Colors.black.withValues(alpha: 0.3),
                             blurRadius: 4,
                             offset: const Offset(0, 2),
                           ),

--- a/lib/widgets/group_avatars.dart
+++ b/lib/widgets/group_avatars.dart
@@ -116,7 +116,7 @@ class GroupAvatars extends StatelessWidget {
           border: Border.all(color: colors.surface, width: 2),
           boxShadow: [
             BoxShadow(
-              color: colors.shadow.withOpacity(0.3),
+              color: colors.shadow.withValues(alpha: 0.3),
               blurRadius: 4,
               offset: const Offset(0, 2),
             ),
@@ -166,7 +166,7 @@ class GroupAvatars extends StatelessWidget {
             border: Border.all(color: colors.surface, width: 2),
             boxShadow: [
               BoxShadow(
-                color: colors.shadow.withOpacity(0.3),
+                color: colors.shadow.withValues(alpha: 0.3),
                 blurRadius: 4,
                 offset: const Offset(0, 2),
               ),
@@ -209,7 +209,7 @@ class GroupAvatars extends StatelessWidget {
         border: Border.all(color: colors.surface, width: 2),
         boxShadow: [
           BoxShadow(
-            color: colors.shadow.withOpacity(0.3),
+            color: colors.shadow.withValues(alpha: 0.3),
             blurRadius: 4,
             offset: const Offset(0, 2),
           ),

--- a/lib/widgets/group_header.dart
+++ b/lib/widgets/group_header.dart
@@ -33,7 +33,7 @@ class GroupHeader extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: colors.surfaceContainerHighest.withOpacity(0.3),
+          color: colors.surfaceContainerHighest.withValues(alpha: 0.3),
           borderRadius: BorderRadius.circular(12),
         ),
         child: Row(

--- a/lib/widgets/group_management_panel.dart
+++ b/lib/widgets/group_management_panel.dart
@@ -64,7 +64,7 @@ class _GroupManagementPanelState extends State<GroupManagementPanel> {
             width: 40,
             height: 4,
             decoration: BoxDecoration(
-              color: colors.onSurfaceVariant.withOpacity(0.3),
+              color: colors.onSurfaceVariant.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(2),
             ),
           ),
@@ -73,7 +73,9 @@ class _GroupManagementPanelState extends State<GroupManagementPanel> {
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
               border: Border(
-                bottom: BorderSide(color: colors.outline.withOpacity(0.2)),
+                bottom: BorderSide(
+                  color: colors.outline.withValues(alpha: 0.2),
+                ),
               ),
             ),
             child: Row(

--- a/lib/widgets/message_bubble/widgets/dialogs/custom_emoji_dialog.dart
+++ b/lib/widgets/message_bubble/widgets/dialogs/custom_emoji_dialog.dart
@@ -50,7 +50,9 @@ class _CustomEmojiDialogState extends State<CustomEmojiDialog> {
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Theme.of(context).colorScheme.outline.withOpacity(0.3),
+                color: Theme.of(
+                  context,
+                ).colorScheme.outline.withValues(alpha: 0.3),
               ),
             ),
             child: TextField(
@@ -64,7 +66,7 @@ class _CustomEmojiDialogState extends State<CustomEmojiDialog> {
                 hintStyle: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
               ),
               onChanged: (value) {
@@ -86,21 +88,23 @@ class _CustomEmojiDialogState extends State<CustomEmojiDialog> {
                     Theme.of(context).colorScheme.primaryContainer,
                     Theme.of(
                       context,
-                    ).colorScheme.primaryContainer.withOpacity(0.7),
+                    ).colorScheme.primaryContainer.withValues(alpha: 0.7),
                   ],
                   begin: Alignment.topLeft,
                   end: Alignment.bottomRight,
                 ),
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(
-                  color: Theme.of(context).colorScheme.primary.withOpacity(0.3),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.primary.withValues(alpha: 0.3),
                   width: 2,
                 ),
                 boxShadow: [
                   BoxShadow(
                     color: Theme.of(
                       context,
-                    ).colorScheme.primary.withOpacity(0.2),
+                    ).colorScheme.primary.withValues(alpha: 0.2),
                     blurRadius: 8,
                     offset: const Offset(0, 2),
                   ),

--- a/lib/widgets/message_bubble/widgets/komet_animated_texts.dart
+++ b/lib/widgets/message_bubble/widgets/komet_animated_texts.dart
@@ -163,7 +163,7 @@ class _PulseAnimatedTextState extends State<PulseAnimatedText>
       builder: (context, child) {
         final t = _controller.value;
         final opacity = 0.5 + (t * 0.5);
-        final color = baseColor.withOpacity(opacity);
+        final color = baseColor.withValues(alpha: opacity);
 
         return Text(
           messageText,

--- a/lib/widgets/message_bubble/widgets/media/audio_player_widget.dart
+++ b/lib/widgets/message_bubble/widgets/media/audio_player_widget.dart
@@ -276,10 +276,10 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
       onLongPress: () {},
       child: Container(
         decoration: BoxDecoration(
-          color: widget.textColor.withOpacity(0.05),
+          color: widget.textColor.withValues(alpha: 0.05),
           borderRadius: widget.borderRadius,
           border: Border.all(
-            color: widget.textColor.withOpacity(0.1),
+            color: widget.textColor.withValues(alpha: 0.1),
             width: 1,
           ),
         ),
@@ -293,7 +293,7 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                   width: 40,
                   height: 40,
                   decoration: BoxDecoration(
-                    color: widget.textColor.withOpacity(0.1),
+                    color: widget.textColor.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
                   child: _isLoading
@@ -304,8 +304,8 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                         )
                       : Icon(
                           _isPlaying ? Icons.pause : Icons.play_arrow,
-                          color: widget.textColor.withOpacity(
-                            0.8 * widget.messageTextOpacity,
+                          color: widget.textColor.withValues(
+                            alpha: 0.8 * widget.messageTextOpacity,
                           ),
                           size: 24,
                         ),
@@ -324,11 +324,11 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                           painter: WaveformPainter(
                             waveform: _waveformData!,
                             progress: progress,
-                            color: widget.textColor.withOpacity(
-                              0.6 * widget.messageTextOpacity,
+                            color: widget.textColor.withValues(
+                              alpha: 0.6 * widget.messageTextOpacity,
                             ),
-                            progressColor: widget.textColor.withOpacity(
-                              0.9 * widget.messageTextOpacity,
+                            progressColor: widget.textColor.withValues(
+                              alpha: 0.9 * widget.messageTextOpacity,
                             ),
                           ),
                           child: LayoutBuilder(
@@ -360,14 +360,16 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                     else
                       SliderTheme(
                         data: SliderTheme.of(context).copyWith(
-                          activeTrackColor: widget.textColor.withOpacity(
-                            0.8 * widget.messageTextOpacity,
+                          activeTrackColor: widget.textColor.withValues(
+                            alpha: 0.8 * widget.messageTextOpacity,
                           ),
-                          inactiveTrackColor: widget.textColor.withOpacity(0.1),
-                          thumbColor: widget.textColor.withOpacity(
-                            0.9 * widget.messageTextOpacity,
+                          inactiveTrackColor: widget.textColor.withValues(
+                            alpha: 0.1,
                           ),
-                          overlayColor: widget.textColor.withOpacity(0.1),
+                          thumbColor: widget.textColor.withValues(
+                            alpha: 0.9 * widget.messageTextOpacity,
+                          ),
+                          overlayColor: widget.textColor.withValues(alpha: 0.1),
                           thumbShape: const RoundSliderThumbShape(
                             enabledThumbRadius: 6,
                           ),
@@ -392,8 +394,8 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                         Text(
                           _formatDuration(_position),
                           style: TextStyle(
-                            color: widget.textColor.withOpacity(
-                              0.7 * widget.messageTextOpacity,
+                            color: widget.textColor.withValues(
+                              alpha: 0.7 * widget.messageTextOpacity,
                             ),
                             fontSize: 12,
                           ),
@@ -403,8 +405,8 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                               ? _formatDuration(_totalDuration)
                               : widget.durationText,
                           style: TextStyle(
-                            color: widget.textColor.withOpacity(
-                              0.7 * widget.messageTextOpacity,
+                            color: widget.textColor.withValues(
+                              alpha: 0.7 * widget.messageTextOpacity,
                             ),
                             fontSize: 12,
                           ),

--- a/lib/widgets/message_preview_dialog.dart
+++ b/lib/widgets/message_preview_dialog.dart
@@ -223,7 +223,7 @@ class ControlMessageChip extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
         margin: const EdgeInsets.symmetric(vertical: 8),
         decoration: BoxDecoration(
-          color: colors.primaryContainer.withOpacity(0.5),
+          color: colors.primaryContainer.withValues(alpha: 0.5),
           borderRadius: BorderRadius.circular(20),
         ),
         child: Text(
@@ -462,7 +462,7 @@ class MessagePreviewDialog {
                     width: 40,
                     height: 4,
                     decoration: BoxDecoration(
-                      color: colors.onSurfaceVariant.withOpacity(0.4),
+                      color: colors.onSurfaceVariant.withValues(alpha: 0.4),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
@@ -474,7 +474,7 @@ class MessagePreviewDialog {
                     decoration: BoxDecoration(
                       border: Border(
                         bottom: BorderSide(
-                          color: colors.outline.withOpacity(0.2),
+                          color: colors.outline.withValues(alpha: 0.2),
                           width: 1,
                         ),
                       ),
@@ -648,7 +648,10 @@ class MessagePreviewDialog {
                           ),
                   ),
                   if (menuBuilder != null) ...[
-                    Divider(height: 1, color: colors.outline.withOpacity(0.2)),
+                    Divider(
+                      height: 1,
+                      color: colors.outline.withValues(alpha: 0.2),
+                    ),
                     menuBuilder(context),
                   ],
                 ],

--- a/lib/widgets/pinned_message_widget.dart
+++ b/lib/widgets/pinned_message_widget.dart
@@ -31,9 +31,12 @@ class PinnedMessageWidget extends StatelessWidget {
       margin: const EdgeInsets.only(left: 8, right: 8, top: 4, bottom: 0),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
-        color: colors.surface.withOpacity(0.6),
+        color: colors.surface.withValues(alpha: 0.6),
         border: Border(
-          bottom: BorderSide(color: colors.outline.withOpacity(0.2), width: 1),
+          bottom: BorderSide(
+            color: colors.outline.withValues(alpha: 0.2),
+            width: 1,
+          ),
         ),
       ),
       child: Row(
@@ -41,7 +44,7 @@ class PinnedMessageWidget extends StatelessWidget {
           Icon(
             Icons.push_pin,
             size: 14,
-            color: colors.primary.withOpacity(0.7),
+            color: colors.primary.withValues(alpha: 0.7),
           ),
           const SizedBox(width: 10),
           Expanded(
@@ -57,7 +60,7 @@ class PinnedMessageWidget extends StatelessWidget {
                         style: TextStyle(
                           fontSize: 13,
                           fontWeight: FontWeight.w500,
-                          color: colors.onSurface.withOpacity(0.7),
+                          color: colors.onSurface.withValues(alpha: 0.7),
                         ),
                       ),
                       TextSpan(
@@ -66,7 +69,7 @@ class PinnedMessageWidget extends StatelessWidget {
                             : 'Вложение',
                         style: TextStyle(
                           fontSize: 13,
-                          color: colors.onSurface.withOpacity(0.9),
+                          color: colors.onSurface.withValues(alpha: 0.9),
                         ),
                       ),
                     ],
@@ -88,7 +91,7 @@ class PinnedMessageWidget extends StatelessWidget {
                   child: Icon(
                     Icons.close,
                     size: 16,
-                    color: colors.onSurface.withOpacity(0.5),
+                    color: colors.onSurface.withValues(alpha: 0.5),
                   ),
                 ),
               ),

--- a/lib/widgets/reconnection_overlay.dart
+++ b/lib/widgets/reconnection_overlay.dart
@@ -19,7 +19,7 @@ class ReconnectionOverlay extends StatelessWidget {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: Material(
-        color: Colors.black.withOpacity(0.7),
+        color: Colors.black.withValues(alpha: 0.7),
         child: Center(
           child: Container(
             padding: const EdgeInsets.all(24),
@@ -28,7 +28,7 @@ class ReconnectionOverlay extends StatelessWidget {
               borderRadius: BorderRadius.circular(16),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.2),
+                  color: Colors.black.withValues(alpha: 0.2),
                   blurRadius: 10,
                   offset: const Offset(0, 4),
                 ),
@@ -67,7 +67,7 @@ class ReconnectionOverlay extends StatelessWidget {
                     fontSize: 14,
                     color: Theme.of(
                       context,
-                    ).colorScheme.onSurface.withOpacity(0.7),
+                    ).colorScheme.onSurface.withValues(alpha: 0.7),
                   ),
                   textAlign: TextAlign.center,
                 ),

--- a/lib/widgets/user_profile_panel.dart
+++ b/lib/widgets/user_profile_panel.dart
@@ -190,7 +190,7 @@ class _UserProfilePanelState extends State<UserProfilePanel> {
             width: 40,
             height: 4,
             decoration: BoxDecoration(
-              color: colors.onSurfaceVariant.withOpacity(0.4),
+              color: colors.onSurfaceVariant.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(2),
             ),
           ),


### PR DESCRIPTION
В этом PR не будет произведено миграции [`ThemeData.dialogBackgroundColor`](https://api.flutter.dev/flutter/material/ThemeData/dialogBackgroundColor.html), так как это решение связано с выбранной системой дизайна. Короче говоря, нужно отдельно обсудить на какой цвет это нужно заменить. Это свойство, из того что я видел, используется в bottom sheets - тогда я бы рекомендовал использовать [`ColorScheme.surfaceContainerLow`](https://api.flutter.dev/flutter/material/ColorScheme/surfaceContainerLow.html) для соответствия официальным гайдлайнам Material 3 Expressive.